### PR TITLE
Feat: Optimize For Loops With Pre-Increments

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -538,7 +538,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         whenNotPaused
     {
         bytes32[] memory dataHashes = new bytes32[](vars.datas.length);
-        for (uint256 i = 0; i < vars.datas.length; i++) {
+        for (uint256 i = 0; i < vars.datas.length; ++i) {
             dataHashes[i] = keccak256(vars.datas[i]);
         }
 

--- a/contracts/core/modules/follow/ApprovalFollowModule.sol
+++ b/contracts/core/modules/follow/ApprovalFollowModule.sol
@@ -38,7 +38,7 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
         address owner = IERC721(HUB).ownerOf(profileId);
         if (msg.sender != owner) revert Errors.NotProfileOwner();
 
-        for (uint256 i = 0; i < addresses.length; i++) {
+        for (uint256 i = 0; i < addresses.length; ++i) {
             _approvedByProfileByOwner[owner][profileId][addresses[i]] = toApprove[i];
         }
 
@@ -63,7 +63,7 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
 
         if (data.length > 0) {
             address[] memory addresses = abi.decode(data, (address[]));
-            for (uint256 i = 0; i < addresses.length; i++) {
+            for (uint256 i = 0; i < addresses.length; ++i) {
                 _approvedByProfileByOwner[owner][profileId][addresses[i]] = true;
             }
         }
@@ -125,7 +125,7 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
         address[] calldata toCheck
     ) external view returns (bool[] memory) {
         bool[] memory approved = new bool[](toCheck.length);
-        for (uint256 i = 0; i < toCheck.length; i++) {
+        for (uint256 i = 0; i < toCheck.length; ++i) {
             approved[i] = _approvedByProfileByOwner[profileOwner][profileId][toCheck[i]];
         }
         return approved;

--- a/contracts/libraries/InteractionLogic.sol
+++ b/contracts/libraries/InteractionLogic.sol
@@ -44,7 +44,7 @@ library InteractionLogic {
         mapping(bytes32 => uint256) storage _profileIdByHandleHash
     ) external {
         if (profileIds.length != followModuleDatas.length) revert Errors.ArrayMismatch();
-        for (uint256 i = 0; i < profileIds.length; i++) {
+        for (uint256 i = 0; i < profileIds.length; ++i) {
             string memory handle = _profileById[profileIds[i]].handle;
             if (_profileIdByHandleHash[keccak256(bytes(handle))] == 0) revert Errors.TokenDoesNotExist();
 

--- a/contracts/libraries/PublishingLogic.sol
+++ b/contracts/libraries/PublishingLogic.sol
@@ -400,7 +400,7 @@ library PublishingLogic {
         if (byteHandle.length == 0 || byteHandle.length > Constants.MAX_HANDLE_LENGTH)
             revert Errors.HandleLengthInvalid();
 
-        for (uint256 i = 0; i < byteHandle.length; i++) {
+        for (uint256 i = 0; i < byteHandle.length; ++i) {
             if (
                 (byteHandle[i] < '0' ||
                     byteHandle[i] > 'z' ||


### PR DESCRIPTION
This simple PR optimizes for loops to use a counter pre-increment instead of a post-increment, so as to save minor gas. This has no effect on the execution flow as the increment is executed after the body of the for loop anyway.