### PR TITLE
Feat: Add a Generic Multi-Follow Test

### DIFF
--- a/test/hub/interactions/following.spec.ts
+++ b/test/hub/interactions/following.spec.ts
@@ -94,6 +94,18 @@ makeSuiteCleanRoom('Following', function () {
         expect(idOne).to.eq(1);
         expect(idTwo).to.eq(2);
       });
+
+      it('UserTwo should follow profile 1 3 times in the same call, receive IDs 1,2 and 3', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID, FIRST_PROFILE_ID, FIRST_PROFILE_ID], [[], [], []])).to.not.be.reverted;
+        const followNFTAddress = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNFT = FollowNFT__factory.connect(followNFTAddress, user);
+        const idOne = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 0);
+        const idTwo = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 1);
+        const idThree = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 2);
+        expect(idOne).to.eq(1);
+        expect(idTwo).to.eq(2);
+        expect(idThree).to.eq(3);
+      });
     });
   });
 
@@ -248,7 +260,7 @@ makeSuiteCleanRoom('Following', function () {
         expect(symbol).to.eq(getAbbreviation(MOCK_PROFILE_HANDLE) + '-Fl');
       });
 
-      it('TestWallet should follow profile 1 with sig twice, receive follow NFTs with IDs 1 and 2', async function () {
+      it('TestWallet should follow profile 1 with sig twice in the same call, receive follow NFTs with IDs 1 and 2', async function () {
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
 
         const { v, r, s } = await getFollowWithSigParts(


### PR DESCRIPTION
This PR adds a corresponding multi-follow test to match the already existing meta-tx multi-follow test and clarifies the latter's test description.