### PR TITLE
Fix: Remove Redundant `Followed()` Event

### DIFF
--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -271,15 +271,6 @@ library Events {
     );
 
     /**
-     * @dev Emitted upon a successful follow action.
-     *
-     * @param follower The address following the profile.
-     * @param profileIds The profile token ID array of the profiles being followed.
-     * @param timestamp The current block timestamp.
-     */
-    event Followed(address indexed follower, uint256[] profileIds, uint256 timestamp);
-
-    /**
      * @dev Emitted when a collectNFT clone is deployed using a lazy deployment pattern.
      *
      * @param profileId The publisher's profile token ID.

--- a/contracts/libraries/InteractionLogic.sol
+++ b/contracts/libraries/InteractionLogic.sol
@@ -46,7 +46,8 @@ library InteractionLogic {
         if (profileIds.length != followModuleDatas.length) revert Errors.ArrayMismatch();
         for (uint256 i = 0; i < profileIds.length; ++i) {
             string memory handle = _profileById[profileIds[i]].handle;
-            if (_profileIdByHandleHash[keccak256(bytes(handle))] == 0) revert Errors.TokenDoesNotExist();
+            if (_profileIdByHandleHash[keccak256(bytes(handle))] == 0)
+                revert Errors.TokenDoesNotExist();
 
             address followModule = _profileById[profileIds[i]].followModule;
 
@@ -79,7 +80,6 @@ library InteractionLogic {
                 );
             }
         }
-        emit Events.Followed(follower, profileIds, block.timestamp);
     }
 
     /**

--- a/test/other/events.spec.ts
+++ b/test/other/events.spec.ts
@@ -451,9 +451,8 @@ makeSuiteCleanRoom('Events', function () {
       const expectedName = MOCK_PROFILE_HANDLE + '-Follower';
       const expectedSymbol = getAbbreviation(MOCK_PROFILE_HANDLE) + '-Fl';
 
-      expect(receipt.logs.length).to.eq(6);
+      expect(receipt.logs.length).to.eq(5);
       matchEvent(receipt, 'FollowNFTDeployed', [FIRST_PROFILE_ID, followNFT, await getTimestamp()]);
-      matchEvent(receipt, 'Followed', [userTwoAddress, [FIRST_PROFILE_ID], await getTimestamp()]);
       matchEvent(receipt, 'BaseInitialized', [expectedName, expectedSymbol, await getTimestamp()]);
       matchEvent(receipt, 'Transfer', [ZERO_ADDRESS, userTwoAddress, 1], lensHubImpl);
       matchEvent(receipt, 'FollowNFTTransferred', [


### PR DESCRIPTION
This PR removes a redundant event. We can track follows via `FollowNFTTransferred()` and don't need `Followed()`.