### PR TITLE
Feat: Update Explorer Verification

### DIFF
--- a/contracts/upgradeability/ProxyBase.sol
+++ b/contracts/upgradeability/ProxyBase.sol
@@ -1,5 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-only
-
-pragma solidity 0.8.10;
-
-import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';

--- a/contracts/upgradeability/TransparentUpgradeableProxy.sol
+++ b/contracts/upgradeability/TransparentUpgradeableProxy.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.0 (proxy/transparent/TransparentUpgradeableProxy.sol)
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * NOTE: This is a direct copy of OpenZeppelin's TransparentUpgradeableProxy and is only present for
+ * ease of explorer verification.
+ *
+ * @dev This contract implements a proxy that is upgradeable by an admin.
+ *
+ * To avoid https://medium.com/nomic-labs-blog/malicious-backdoors-in-ethereum-proxies-62629adf3357[proxy selector
+ * clashing], which can potentially be used in an attack, this contract uses the
+ * https://blog.openzeppelin.com/the-transparent-proxy-pattern/[transparent proxy pattern]. This pattern implies two
+ * things that go hand in hand:
+ *
+ * 1. If any account other than the admin calls the proxy, the call will be forwarded to the implementation, even if
+ * that call matches one of the admin functions exposed by the proxy itself.
+ * 2. If the admin calls the proxy, it can access the admin functions, but its calls will never be forwarded to the
+ * implementation. If the admin tries to call a function on the implementation it will fail with an error that says
+ * "admin cannot fallback to proxy target".
+ *
+ * These properties mean that the admin account can only be used for admin actions like upgrading the proxy or changing
+ * the admin, so it's best if it's a dedicated account that is not used for anything else. This will avoid headaches due
+ * to sudden errors when trying to call a function from the proxy implementation.
+ *
+ * Our recommendation is for the dedicated account to be an instance of the {ProxyAdmin} contract. If set up this way,
+ * you should think of the `ProxyAdmin` instance as the real administrative interface of your proxy.
+ */
+contract TransparentUpgradeableProxy is ERC1967Proxy {
+    /**
+     * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
+     * optionally initialized with `_data` as explained in {ERC1967Proxy-constructor}.
+     */
+    constructor(
+        address _logic,
+        address admin_,
+        bytes memory _data
+    ) payable ERC1967Proxy(_logic, _data) {
+        assert(_ADMIN_SLOT == bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1));
+        _changeAdmin(admin_);
+    }
+
+    /**
+     * @dev Modifier used internally that will delegate the call to the implementation unless the sender is the admin.
+     */
+    modifier ifAdmin() {
+        if (msg.sender == _getAdmin()) {
+            _;
+        } else {
+            _fallback();
+        }
+    }
+
+    /**
+     * @dev Returns the current admin.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyAdmin}.
+     *
+     * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
+     * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
+     * `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
+     */
+    function admin() external ifAdmin returns (address admin_) {
+        admin_ = _getAdmin();
+    }
+
+    /**
+     * @dev Returns the current implementation.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyImplementation}.
+     *
+     * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
+     * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
+     * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
+     */
+    function implementation() external ifAdmin returns (address implementation_) {
+        implementation_ = _implementation();
+    }
+
+    /**
+     * @dev Changes the admin of the proxy.
+     *
+     * Emits an {AdminChanged} event.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-changeProxyAdmin}.
+     */
+    function changeAdmin(address newAdmin) external virtual ifAdmin {
+        _changeAdmin(newAdmin);
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
+     */
+    function upgradeTo(address newImplementation) external ifAdmin {
+        _upgradeToAndCall(newImplementation, bytes(""), false);
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy, and then call a function from the new implementation as specified
+     * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
+     * proxied contract.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
+     */
+    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable ifAdmin {
+        _upgradeToAndCall(newImplementation, data, true);
+    }
+
+    /**
+     * @dev Returns the current admin.
+     */
+    function _admin() internal view virtual returns (address) {
+        return _getAdmin();
+    }
+
+    /**
+     * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
+     */
+    function _beforeFallback() internal virtual override {
+        require(msg.sender != _getAdmin(), "TransparentUpgradeableProxy: admin cannot fallback to proxy target");
+        super._beforeFallback();
+    }
+}

--- a/tasks/full-deploy-verify.ts
+++ b/tasks/full-deploy-verify.ts
@@ -7,7 +7,6 @@ import {
   LensHub__factory,
   ApprovalFollowModule__factory,
   CollectNFT__factory,
-  Currency__factory,
   EmptyCollectModule__factory,
   FeeCollectModule__factory,
   FeeFollowModule__factory,
@@ -30,6 +29,18 @@ const LENS_HUB_NFT_SYMBOL = 'VVGT';
 
 export let runtimeHRE: HardhatRuntimeEnvironment;
 
+/**
+ * @dev Note that this script uses the default ethers signers.
+1 * Care should be taken to also ensure that the following addresses end up properly set:
+ *    1. LensHub Proxy Admin
+ *    2. LensHub Governance
+ *    3. ModuleGlobals Governance
+ *    3. ModuleGlobals Treasury
+ *  
+ * Furthermore, This script does not whitelist profile creators or deploy a profile creation 
+ * proxy or a unique currency contract. This also does not whitelist any currencies in the
+ * ModuleGlobals contract.
+ */
 task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verification').setAction(
   async ({}, hre) => {
     // Note that the use of these signers is a placeholder and is not meant to be used in
@@ -131,14 +142,6 @@ task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verif
 
     // Connect the hub proxy to the LensHub factory and the governance for ease of use.
     const lensHub = LensHub__factory.connect(proxy.address, governance);
-
-    // Currency
-    console.log('\n\t-- Deploying Currency --');
-    const currency = await deployWithVerify(
-      new Currency__factory(deployer).deploy({ nonce: deployerNonce++ }),
-      [],
-      'contracts/mocks/Currency.sol:Currency'
-    );
 
     // Deploy collect modules
     console.log('\n\t-- Deploying feeCollectModule --');
@@ -270,14 +273,6 @@ task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verif
       })
     );
 
-    // Whitelist the currency
-    console.log('\n\t-- Whitelisting Currency in Module Globals --');
-    await waitForTx(
-      moduleGlobals
-        .connect(governance)
-        .whitelistCurrency(currency.address, true, { nonce: governanceNonce++ })
-    );
-
     // Save and log the addresses
     const addrs = {
       'lensHub proxy': lensHub.address,
@@ -286,7 +281,6 @@ task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verif
       'interaction logic lib': interactionLogic.address,
       'follow NFT impl': followNFTImplAddress,
       'collect NFT impl': collectNFTImplAddress,
-      currency: currency.address,
       'module globals': moduleGlobals.address,
       'fee collect module': feeCollectModule.address,
       'limited fee collect module': limitedFeeCollectModule.address,

--- a/tasks/full-deploy-verify.ts
+++ b/tasks/full-deploy-verify.ts
@@ -126,7 +126,7 @@ task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verif
         { nonce: deployerNonce++ }
       ),
       [lensHubImpl.address, deployer.address, data],
-      '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol'
+      'contracts/upgradeability/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy'
     );
 
     // Connect the hub proxy to the LensHub factory and the governance for ease of use.

--- a/tasks/helpers/utils.ts
+++ b/tasks/helpers/utils.ts
@@ -36,7 +36,7 @@ export async function deployWithVerify(
 ): Promise<Contract> {
   const deployedContract = await deployContract(tx);
   let count = 0;
-  let maxTries = 5;
+  let maxTries = 7;
   while (true) {
     await delay(5000);
     try {


### PR DESCRIPTION
This PR updates the explorer (whateverscan) verification script to properly verify the upgradeability proxy while not including mock currency deployments. There are also some descriptive comments added detailing what should be done pre/post deployment (changing signers, setting roles, whitelisting currencies, etc).