### PR TITLE
Feature/proposal to track profile who did the actions aka follow / collect etc

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -518,19 +518,19 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     /// @inheritdoc ILensHub
     function follow(
         uint256[] calldata profileIds,
-        uint256[] memory referralProfileIds,
+        uint256[] memory followedFromProfileIds,
         bytes[] calldata datas
     ) external override whenNotPaused {
-        for (uint256 i = 0; i < referralProfileIds.length; i++) {
-            if (referralProfileIds[i] != 0) {
-                _validateCallerIsProfileOwner(referralProfileIds[i]);
+        for (uint256 i = 0; i < followedFromProfileIds.length; i++) {
+            if (followedFromProfileIds[i] != 0) {
+                _validateCallerIsProfileOwner(followedFromProfileIds[i]);
             }
         }
 
         InteractionLogic.follow(
             msg.sender,
             profileIds,
-            referralProfileIds,
+            followedFromProfileIds,
             datas,
             FOLLOW_NFT_IMPL,
             _profileById,
@@ -545,12 +545,12 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         whenNotPaused
     {
         bytes32[] memory dataHashes = new bytes32[](vars.datas.length);
-        // vars.data always must be same length to vars.referralProfileIds and vars.profileIds
+        // vars.data always must be same length to vars.followedFromProfileIds and vars.profileIds
         for (uint256 i = 0; i < vars.datas.length; ++i) {
             dataHashes[i] = keccak256(vars.datas[i]);
 
-            if (vars.referralProfileIds[i] != 0) {
-                _validateAddressIsProfileOwner(vars.follower, vars.referralProfileIds[i]);
+            if (vars.followedFromProfileIds[i] != 0) {
+                _validateAddressIsProfileOwner(vars.follower, vars.followedFromProfileIds[i]);
             }
         }
 
@@ -577,7 +577,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         InteractionLogic.follow(
             vars.follower,
             vars.profileIds,
-            vars.referralProfileIds,
+            vars.followedFromProfileIds,
             vars.datas,
             FOLLOW_NFT_IMPL,
             _profileById,
@@ -590,10 +590,10 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         uint256 profileId,
         uint256 pubId,
         bytes calldata data,
-        uint256 referralProfileId
+        uint256 followedFromProfileId
     ) external override whenNotPaused {
-        if (referralProfileId != 0) {
-            _validateCallerIsProfileOwner(referralProfileId);
+        if (followedFromProfileId != 0) {
+            _validateCallerIsProfileOwner(followedFromProfileId);
         }
 
         InteractionLogic.collect(
@@ -601,7 +601,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
             profileId,
             pubId,
             data,
-            referralProfileId,
+            followedFromProfileId,
             COLLECT_NFT_IMPL,
             _pubByIdByProfile,
             _profileById
@@ -614,8 +614,8 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         override
         whenNotPaused
     {
-        if (vars.referralProfileId != 0) {
-            _validateAddressIsProfileOwner(vars.collector, vars.referralProfileId);
+        if (vars.followedFromProfileId != 0) {
+            _validateAddressIsProfileOwner(vars.collector, vars.followedFromProfileId);
         }
 
         bytes32 digest;
@@ -644,7 +644,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
             vars.profileId,
             vars.pubId,
             vars.data,
-            vars.referralProfileId,
+            vars.followedFromProfileId,
             COLLECT_NFT_IMPL,
             _pubByIdByProfile,
             _profileById

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -211,12 +211,18 @@ interface ILensHub {
     /**
      * @notice Follows the given profiles, executing each profile's follow module logic (if any) and minting followNFTs to the caller.
      *
-     * NOTE: Both the `profileIds` and `datas` arrays must be of the same length, regardless if the profiles do not have a follow module set.
+     * NOTE: Both the `profileIds`, `referralProfileIds` and `datas` arrays must be of the same length, regardless if the profiles do not have a follow module set
+             or do not want to link the follow action to one of their profiles.
      *
      * @param profileIds The token ID array of the profiles to follow.
+     * @param referralProfileIds The array of profile token IDs you want to link the follow to.
      * @param datas The arbitrary data array to pass to the follow module for each profile if needed.
      */
-    function follow(uint256[] calldata profileIds, bytes[] calldata datas) external;
+    function follow(
+        uint256[] calldata profileIds,
+        uint256[] memory referralProfileIds,
+        bytes[] calldata datas
+    ) external;
 
     /**
      * @notice Follows a given profile via signature with the specified parameters.
@@ -232,11 +238,13 @@ interface ILensHub {
      * @param profileId The token ID of the profile that published the publication to collect.
      * @param pubId The publication to collect's publication ID.
      * @param data The arbitrary data to pass to the collect module if needed.
+     * @param referralProfileId The profile token ID you want to link the collect from.
      */
     function collect(
         uint256 profileId,
         uint256 pubId,
-        bytes calldata data
+        bytes calldata data,
+        uint256 referralProfileId
     ) external;
 
     /**

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -211,16 +211,16 @@ interface ILensHub {
     /**
      * @notice Follows the given profiles, executing each profile's follow module logic (if any) and minting followNFTs to the caller.
      *
-     * NOTE: Both the `profileIds`, `referralProfileIds` and `datas` arrays must be of the same length, regardless if the profiles do not have a follow module set
+     * NOTE: Both the `profileIds`, `followedFromProfileIds` and `datas` arrays must be of the same length, regardless if the profiles do not have a follow module set
              or do not want to link the follow action to one of their profiles.
      *
      * @param profileIds The token ID array of the profiles to follow.
-     * @param referralProfileIds The array of profile token IDs you want to link the follow to.
+     * @param followedFromProfileIds The array of profile token IDs you want to link the action of the follow from (can be 0 if you dont want to link).
      * @param datas The arbitrary data array to pass to the follow module for each profile if needed.
      */
     function follow(
         uint256[] calldata profileIds,
-        uint256[] memory referralProfileIds,
+        uint256[] memory followedFromProfileIds,
         bytes[] calldata datas
     ) external;
 
@@ -238,13 +238,13 @@ interface ILensHub {
      * @param profileId The token ID of the profile that published the publication to collect.
      * @param pubId The publication to collect's publication ID.
      * @param data The arbitrary data to pass to the collect module if needed.
-     * @param referralProfileId The profile token ID you want to link the collect from.
+     * @param followedFromProfileId The profile token ID you want to link the action of a collect from (can be 0 if you dont want to link).
      */
     function collect(
         uint256 profileId,
         uint256 pubId,
         bytes calldata data,
-        uint256 referralProfileId
+        uint256 followedFromProfileId
     ) external;
 
     /**

--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -300,12 +300,14 @@ library DataTypes {
      *
      * @param follower The follower which is the message signer.
      * @param profileIds The array of token IDs of the profiles to follow.
+     * @param referralProfileIds The array of profile token IDs you want to link the follow to.
      * @param datas The array of arbitrary data to pass to the followModules if needed.
      * @param sig The EIP712Signature struct containing the follower's signature.
      */
     struct FollowWithSigData {
         address follower;
         uint256[] profileIds;
+        uint256[] referralProfileIds;
         bytes[] datas;
         EIP712Signature sig;
     }
@@ -318,6 +320,7 @@ library DataTypes {
      * @param profileId The token ID of the profile that published the publication to collect.
      * @param pubId The publication to collect's publication ID.
      * @param data The arbitrary data to pass to the collectModule if needed.
+     * @param referralProfileId The profile token ID you want to link the collect from.
      * @param sig The EIP712Signature struct containing the collector's signature.
      */
     struct CollectWithSigData {
@@ -325,6 +328,7 @@ library DataTypes {
         uint256 profileId;
         uint256 pubId;
         bytes data;
+        uint256 referralProfileId;
         EIP712Signature sig;
     }
 }

--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -300,14 +300,14 @@ library DataTypes {
      *
      * @param follower The follower which is the message signer.
      * @param profileIds The array of token IDs of the profiles to follow.
-     * @param referralProfileIds The array of profile token IDs you want to link the follow to.
+     * @param followedFromProfileIds The array of profile token IDs you want to link the action of the follow from (can be 0 if you dont want to link).
      * @param datas The array of arbitrary data to pass to the followModules if needed.
      * @param sig The EIP712Signature struct containing the follower's signature.
      */
     struct FollowWithSigData {
         address follower;
         uint256[] profileIds;
-        uint256[] referralProfileIds;
+        uint256[] followedFromProfileIds;
         bytes[] datas;
         EIP712Signature sig;
     }
@@ -320,7 +320,7 @@ library DataTypes {
      * @param profileId The token ID of the profile that published the publication to collect.
      * @param pubId The publication to collect's publication ID.
      * @param data The arbitrary data to pass to the collectModule if needed.
-     * @param referralProfileId The profile token ID you want to link the collect from.
+     * @param followedFromProfileId The profile token ID you want to link the action of a collect from (can be 0 if you dont want to link).
      * @param sig The EIP712Signature struct containing the collector's signature.
      */
     struct CollectWithSigData {
@@ -328,7 +328,7 @@ library DataTypes {
         uint256 profileId;
         uint256 pubId;
         bytes data;
-        uint256 referralProfileId;
+        uint256 followedFromProfileId;
         EIP712Signature sig;
     }
 }

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -271,6 +271,21 @@ library Events {
     );
 
     /**
+     * @dev Emitted upon a successful follow action.
+     *
+     * @param follower The address following the profile.
+     * @param profileIds The profile token ID array of the profiles being followed.
+     * @param referralProfileIds The array of profile token IDs you want to link the follow to.
+     * @param timestamp The current block timestamp.
+     */
+    event Followed(
+        address indexed follower,
+        uint256[] profileIds,
+        uint256[] referralProfileIds,
+        uint256 timestamp
+    );
+
+    /**
      * @dev Emitted when a collectNFT clone is deployed using a lazy deployment pattern.
      *
      * @param profileId The publisher's profile token ID.
@@ -291,6 +306,7 @@ library Events {
      * @param collector The address collecting the publication.
      * @param profileId The token ID of the profile that the collect was initiated towards, useful to differentiate mirrors.
      * @param pubId The publication ID that the collect was initiated towards, useful to differentiate mirrors.
+     * @param referralProfileId The profile token ID you want to link the collect from.
      * @param rootProfileId The profile token ID of the profile whose publication is being collected.
      * @param rootPubId The publication ID of the publication being collected.
      * @param timestamp The current block timestamp.
@@ -299,6 +315,7 @@ library Events {
         address indexed collector,
         uint256 indexed profileId,
         uint256 indexed pubId,
+        uint256 referralProfileId,
         uint256 rootProfileId,
         uint256 rootPubId,
         uint256 timestamp

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -275,13 +275,13 @@ library Events {
      *
      * @param follower The address following the profile.
      * @param profileIds The profile token ID array of the profiles being followed.
-     * @param referralProfileIds The array of profile token IDs you want to link the follow to.
+     * @param followedFromProfileIds The array of profile token IDs you want to link the action of the follow from (can be 0 if you dont want to link).
      * @param timestamp The current block timestamp.
      */
     event Followed(
         address indexed follower,
         uint256[] profileIds,
-        uint256[] referralProfileIds,
+        uint256[] followedFromProfileIds,
         uint256 timestamp
     );
 
@@ -306,7 +306,7 @@ library Events {
      * @param collector The address collecting the publication.
      * @param profileId The token ID of the profile that the collect was initiated towards, useful to differentiate mirrors.
      * @param pubId The publication ID that the collect was initiated towards, useful to differentiate mirrors.
-     * @param referralProfileId The profile token ID you want to link the collect from.
+     * @param followedFromProfileId The profile token ID you want to link the action of a collect from (can be 0 if you dont want to link).
      * @param rootProfileId The profile token ID of the profile whose publication is being collected.
      * @param rootPubId The publication ID of the publication being collected.
      * @param timestamp The current block timestamp.
@@ -315,7 +315,7 @@ library Events {
         address indexed collector,
         uint256 indexed profileId,
         uint256 indexed pubId,
-        uint256 referralProfileId,
+        uint256 followedFromProfileId,
         uint256 rootProfileId,
         uint256 rootPubId,
         uint256 timestamp

--- a/contracts/libraries/InteractionLogic.sol
+++ b/contracts/libraries/InteractionLogic.sol
@@ -31,7 +31,7 @@ library InteractionLogic {
      *
      * @param follower The address executing the follow.
      * @param profileIds The array of profile token IDs to follow.
-     * @param referralProfileIds The array of profile token IDs you want to link the follow to.
+     * @param followedFromProfileIds The array of profile token IDs you want to link the action of the follow from (can be 0 if you dont want to link).
      * @param followModuleDatas The array of follow module data parameters to pass to each profile's follow module.
      * @param followNFTImpl The address of the follow NFT implementation, which has to be passed because it's an immutable in the hub.
      * @param _profileById A pointer to the storage mapping of profile structs by profile ID.
@@ -39,7 +39,7 @@ library InteractionLogic {
     function follow(
         address follower,
         uint256[] calldata profileIds,
-        uint256[] memory referralProfileIds,
+        uint256[] memory followedFromProfileIds,
         bytes[] calldata followModuleDatas,
         address followNFTImpl,
         mapping(uint256 => DataTypes.ProfileStruct) storage _profileById,
@@ -81,7 +81,7 @@ library InteractionLogic {
             }
         }
 
-        emit Events.Followed(follower, profileIds, referralProfileIds, block.timestamp);
+        emit Events.Followed(follower, profileIds, followedFromProfileIds, block.timestamp);
     }
 
     /**
@@ -92,7 +92,7 @@ library InteractionLogic {
      * @param profileId The token ID of the publication being collected's parent profile.
      * @param pubId The publication ID of the publication being collected.
      * @param collectModuleData The data to pass to the publication's collect module.
-     * @param referralProfileId The profile token ID you want to link the collect from.
+     * @param followedFromProfileId The profile token ID you want to link the action of a collect from (can be 0 if you dont want to link).
      * @param collectNFTImpl The address of the collect NFT implementation, which has to be passed because it's an immutable in the hub.
      * @param _pubByIdByProfile A pointer to the storage mapping of publications by pubId by profile ID.
      * @param _profileById A pointer to the storage mapping of profile structs by profile ID.
@@ -102,7 +102,7 @@ library InteractionLogic {
         uint256 profileId,
         uint256 pubId,
         bytes calldata collectModuleData,
-        uint256 referralProfileId,
+        uint256 followedFromProfileId,
         address collectNFTImpl,
         mapping(uint256 => mapping(uint256 => DataTypes.PublicationStruct))
             storage _pubByIdByProfile,
@@ -153,7 +153,7 @@ library InteractionLogic {
             collector,
             profileId,
             pubId,
-            referralProfileId,
+            followedFromProfileId,
             rootProfileId,
             rootPubId,
             block.timestamp


### PR DESCRIPTION
With wallet being able to follow and collect as the main ethos of this protocol you do hit some UI/UX issues when trying to display this to the users. If you can tag the profileIds you did the action on this allows you to show notifications based on the profile itself same with followers. 

Yes you would have some edge cases where:

- 0x...01 follows @josh passing in profileFollowedWith @cat
- UI shows 0x..01 follows me from @cat 
- 0x..01 sells @cat to 0x..01
- 0x..01 still follows @cat but now doesn't own a profile so you would have to handle this case here on UI 

but overall it allows UIs greater flexibility to at least link some of this data together! These few event changes allow the indexer to match this all up! 