### PR TITLE
Fix/test Replace old getLatestData function call by new one

### DIFF
--- a/test/other/misc.spec.ts
+++ b/test/other/misc.spec.ts
@@ -690,7 +690,7 @@ makeSuiteCleanRoom('Misc', function () {
       const dataProvider = await new UIDataProvider__factory(deployer).deploy(lensHub.address);
 
       // Lastly, validate the result from the data provider
-      const result = await dataProvider.getLatestData(FIRST_PROFILE_ID);
+      const result = await dataProvider.getLatestDataByProfile(FIRST_PROFILE_ID);
       const pubStruct = result.publicationStruct;
       const profileStruct = result.profileStruct;
 


### PR DESCRIPTION
Changes introduced here https://github.com/aave/lens-protocol/commit/a9aadfc27c13ac37b17b48766690b811e1c45f30 broke the tests.

`getLatestDataByProfile` introduced in replacement for `getLatestData` in `contracts/misc/UIDataProvider.sol` contract helper