### PR TITLE
feat: allow to set default profile

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -223,7 +223,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
 
         _validateRecoveredAddress(digest, owner, vars.sig);
 
-        _setDefaultProfile(vars.profileId, owner);
+        _unsetDefaultProfile(vars.profileId, owner);
     }
 
     /// @inheritdoc ILensHub

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -965,7 +965,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         _defaultProfileByAddress[profileId] = address(0);
         _addressByDefaultProfile[owner] = 0;
 
-        emit Events.DefaultProfileSet(0, address(0), block.timestamp);
+        emit Events.DefaultProfileUnset(profileId, owner, block.timestamp);
     }
 
     function _createComment(DataTypes.CommentData memory vars) internal {

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -1029,7 +1029,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         }
 
         _defaultProfileByAddress[tokenId] = address(0);
-        _addressByDefaultProfile[msg.sender] = 0;
+        _addressByDefaultProfile[from] = 0;
         super._beforeTokenTransfer(from, to, tokenId);
     }
 

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -712,7 +712,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
 
     /// @inheritdoc ILensHub
     function defaultProfile(address wallet) external view override returns (uint256) {
-        return _addressToDefaultProfile[wallet];
+        return _defaultProfileByAddress[wallet];
     }
 
     /// @inheritdoc ILensHub
@@ -921,14 +921,14 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         // you should only be able to map this to the owner OR dead address
         if (wallet != address(0)) {
             _validateCallerIsProfileOwner(profileId, wallet);
-            _addressToDefaultProfile[wallet] = profileId;
-            _defaultProfileToAddress[profileId] = wallet;
+            _defaultProfileByAddress[wallet] = profileId;
+            _addressByDefaultProfile[profileId] = wallet;
 
             emit Events.DefaultProfileSet(profileId, wallet, block.timestamp);
         } else {
             // unset the default
-            _addressToDefaultProfile[ownerOf(profileId)] = 0;
-            _defaultProfileToAddress[profileId] = wallet;
+            _defaultProfileByAddress[ownerOf(profileId)] = 0;
+            _addressByDefaultProfile[profileId] = wallet;
 
             emit Events.DefaultProfileSet(0, wallet, block.timestamp);
         }
@@ -995,8 +995,8 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         }
 
         if (from != address(0)) {
-            _defaultProfileToAddress[tokenId] = address(0);
-            _addressToDefaultProfile[from] = 0;
+            _addressByDefaultProfile[tokenId] = address(0);
+            _defaultProfileByAddress[from] = 0;
         }
 
         super._beforeTokenTransfer(from, to, tokenId);

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -1028,8 +1028,11 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
             _setDispatcher(tokenId, address(0));
         }
 
-        _defaultProfileByAddress[tokenId] = address(0);
-        _addressByDefaultProfile[from] = 0;
+        if (from != address(0)) {
+            _defaultProfileByAddress[tokenId] = address(0);
+            _addressByDefaultProfile[from] = 0;
+        }
+
         super._beforeTokenTransfer(from, to, tokenId);
     }
 

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -920,7 +920,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     function _setDefaultProfile(uint256 profileId, address wallet) internal {
         // you should only be able to map this to the owner OR dead address
         if (wallet != address(0)) {
-            _validateCallerIsProfileOwner(profileId, wallet);
+            _validateWalletIsProfileOwner(profileId, wallet);
             _defaultProfileByAddress[wallet] = profileId;
             _addressByDefaultProfile[profileId] = wallet;
 
@@ -1011,7 +1011,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         if (msg.sender != ownerOf(profileId)) revert Errors.NotProfileOwner();
     }
 
-    function _validateCallerIsProfileOwner(uint256 profileId, address wallet) internal view {
+    function _validateWalletIsProfileOwner(uint256 profileId, address wallet) internal view {
         if (wallet != ownerOf(profileId)) revert Errors.NotProfileOwner();
     }
 

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -157,9 +157,9 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     }
 
     /// @inheritdoc ILensHub
-    function setDefaultProfile(uint256 profileId, address owner) external override whenNotPaused {
+    function setDefaultProfile(uint256 profileId, address wallet) external override whenNotPaused {
         _validateCallerIsProfileOwnerOrDispatcher(profileId);
-        _setDefaultProfile(profileId, owner);
+        _setDefaultProfile(profileId, wallet);
     }
 
     /// @inheritdoc ILensHub
@@ -916,16 +916,16 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         );
     }
 
-    function _setDefaultProfile(uint256 profileId, address owner) internal {
+    function _setDefaultProfile(uint256 profileId, address wallet) internal {
         // you should only be able to map this to the owner OR dead address
-        if (owner != address(0)) {
-            _validateCallerIsProfileOwner(profileId, owner);
+        if (wallet != address(0)) {
+            _validateCallerIsProfileOwner(profileId, wallet);
         }
 
-        _defaultProfileToAddress[profileId] = owner;
-        _addressToDefaultProfile[owner] = profileId;
+        _defaultProfileToAddress[profileId] = wallet;
+        _addressToDefaultProfile[wallet] = profileId;
 
-        emit Events.DefaultProfileSet(profileId, owner, block.timestamp);
+        emit Events.DefaultProfileSet(profileId, wallet, block.timestamp);
     }
 
     function _createComment(DataTypes.CommentData memory vars) internal {

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -158,7 +158,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
 
     /// @inheritdoc ILensHub
     function setDefaultProfile(uint256 profileId, address owner) external override whenNotPaused {
-        _validateCallerIsProfileOwner(profileId, msg.sender);
+        _validateCallerIsProfileOwnerOrDispatcher(profileId);
         _setDefaultProfile(profileId, owner);
     }
 
@@ -917,7 +917,10 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     }
 
     function _setDefaultProfile(uint256 profileId, address owner) internal {
-        _validateCallerIsProfileOwner(profileId, owner);
+        // you should only be able to map this to the owner OR dead address
+        if (owner != address(0)) {
+            _validateCallerIsProfileOwner(profileId, owner);
+        }
 
         _defaultProfileToAddress[profileId] = owner;
         _addressToDefaultProfile[owner] = profileId;

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -745,7 +745,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
 
     /// @inheritdoc ILensHub
     function defaultProfile(address wallet) external view override returns (uint256) {
-        return _addressByDefaultProfile[wallet];
+        return _addressToDefaultProfile[wallet];
     }
 
     /// @inheritdoc ILensHub
@@ -953,8 +953,8 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     function _setDefaultProfile(uint256 profileId, address owner) internal {
         _validateCallerIsProfileOwner(profileId, owner);
 
-        _defaultProfileByAddress[profileId] = owner;
-        _addressByDefaultProfile[owner] = profileId;
+        _defaultProfileToAddress[profileId] = owner;
+        _addressToDefaultProfile[owner] = profileId;
 
         emit Events.DefaultProfileSet(profileId, owner, block.timestamp);
     }
@@ -962,8 +962,8 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     function _unsetDefaultProfile(uint256 profileId, address owner) internal {
         _validateCallerIsProfileOwner(profileId, owner);
 
-        _defaultProfileByAddress[profileId] = address(0);
-        _addressByDefaultProfile[owner] = 0;
+        _defaultProfileToAddress[profileId] = address(0);
+        _addressToDefaultProfile[owner] = 0;
 
         emit Events.DefaultProfileUnset(profileId, owner, block.timestamp);
     }
@@ -1029,8 +1029,8 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         }
 
         if (from != address(0)) {
-            _defaultProfileByAddress[tokenId] = address(0);
-            _addressByDefaultProfile[from] = 0;
+            _defaultProfileToAddress[tokenId] = address(0);
+            _addressToDefaultProfile[from] = 0;
         }
 
         super._beforeTokenTransfer(from, to, tokenId);

--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -15,11 +15,6 @@ contract LensHubStorage {
     // keccak256(
     // 'setDefaultProfileWithSig(uint256 profileId,uint256 nonce,uint256 deadline)'
     // );
-    bytes32 internal constant UNSET_DEFAULT_PROFILE_WITH_SIG_TYPEHASH =
-        0x2c0999aca14a6108b99d0483911154022cf8071dfe55ac3325ccd3e28e12a3c2;
-    // keccak256(
-    // 'unsetDefaultProfileWithSig(uint256 profileId,uint256 nonce,uint256 deadline)'
-    // );
     bytes32 internal constant SET_FOLLOW_MODULE_WITH_SIG_TYPEHASH =
         0x6f3f6455a608af1cc57ef3e5c0a49deeb88bba264ec8865b798ff07358859d4b;
     // keccak256(

--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -10,8 +10,18 @@ contract LensHubStorage {
     // keccak256(
     // 'CreateProfileWithSig(string handle,string uri,address followModule,bytes followModuleData,uint256 nonce,uint256 deadline)'
     // );
+    bytes32 internal constant SET_DEFAULT_PROFILE_WITH_SIG_TYPEHASH =
+        0x76a7f2df5a2c73b8b0bbf095e1efae3cc5fb722c9a4000d53c90aa1848421fd5;
+    // keccak256(
+    // 'setDefaultProfileWithSig(uint256 profileId,uint256 nonce,uint256 deadline)'
+    // );
+    bytes32 internal constant UNSET_DEFAULT_PROFILE_WITH_SIG_TYPEHASH =
+        0x2c0999aca14a6108b99d0483911154022cf8071dfe55ac3325ccd3e28e12a3c2;
+    // keccak256(
+    // 'unsetDefaultProfileWithSig(uint256 profileId,uint256 nonce,uint256 deadline)'
+    // );
     bytes32 internal constant SET_FOLLOW_MODULE_WITH_SIG_TYPEHASH =
-        0x6f3f6455a608af1cc57ef3e5c0a49deeb88bba264ec8865b798ff07358859d4b;
+        0x5d91a73d4b313d08b27193d276cd37aadd617e55d521190e2f80dc2217a9066f;
     // keccak256(
     // 'SetFollowModuleWithSig(uint256 profileId,address followModule,bytes followModuleData,uint256 nonce,uint256 deadline)'
     // );
@@ -65,6 +75,9 @@ contract LensHubStorage {
     mapping(bytes32 => uint256) internal _profileIdByHandleHash;
     mapping(uint256 => DataTypes.ProfileStruct) internal _profileById;
     mapping(uint256 => mapping(uint256 => DataTypes.PublicationStruct)) internal _pubByIdByProfile;
+
+    mapping(uint256 => address) internal _defaultProfileByAddress;
+    mapping(address => uint256) internal _addressByDefaultProfile;
 
     uint256 internal _profileCounter;
     address internal _governance;

--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -76,8 +76,8 @@ contract LensHubStorage {
     mapping(uint256 => DataTypes.ProfileStruct) internal _profileById;
     mapping(uint256 => mapping(uint256 => DataTypes.PublicationStruct)) internal _pubByIdByProfile;
 
-    mapping(uint256 => address) internal _defaultProfileByAddress;
-    mapping(address => uint256) internal _addressByDefaultProfile;
+    mapping(uint256 => address) internal _defaultProfileToAddress;
+    mapping(address => uint256) internal _addressToDefaultProfile;
 
     uint256 internal _profileCounter;
     address internal _governance;

--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -11,9 +11,9 @@ contract LensHubStorage {
     // 'CreateProfileWithSig(string handle,string uri,address followModule,bytes followModuleData,uint256 nonce,uint256 deadline)'
     // );
     bytes32 internal constant SET_DEFAULT_PROFILE_WITH_SIG_TYPEHASH =
-        0x76a7f2df5a2c73b8b0bbf095e1efae3cc5fb722c9a4000d53c90aa1848421fd5;
+        0xae4d0f1a57c80ed196993d814b14f19b25a688b09b9cb0467c33d76e022c216f;
     // keccak256(
-    // 'setDefaultProfileWithSig(uint256 profileId,uint256 nonce,uint256 deadline)'
+    // 'SetDefaultProfileWithSig(uint256 profileId,address wallet,uint256 nonce,uint256 deadline)'
     // );
     bytes32 internal constant SET_FOLLOW_MODULE_WITH_SIG_TYPEHASH =
         0x6f3f6455a608af1cc57ef3e5c0a49deeb88bba264ec8865b798ff07358859d4b;

--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -71,8 +71,8 @@ contract LensHubStorage {
     mapping(uint256 => DataTypes.ProfileStruct) internal _profileById;
     mapping(uint256 => mapping(uint256 => DataTypes.PublicationStruct)) internal _pubByIdByProfile;
 
-    mapping(uint256 => address) internal _defaultProfileToAddress;
-    mapping(address => uint256) internal _addressToDefaultProfile;
+    mapping(uint256 => address) internal _addressByDefaultProfile;
+    mapping(address => uint256) internal _defaultProfileByAddress;
 
     uint256 internal _profileCounter;
     address internal _governance;

--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -21,7 +21,7 @@ contract LensHubStorage {
     // 'unsetDefaultProfileWithSig(uint256 profileId,uint256 nonce,uint256 deadline)'
     // );
     bytes32 internal constant SET_FOLLOW_MODULE_WITH_SIG_TYPEHASH =
-        0x5d91a73d4b313d08b27193d276cd37aadd617e55d521190e2f80dc2217a9066f;
+        0x6f3f6455a608af1cc57ef3e5c0a49deeb88bba264ec8865b798ff07358859d4b;
     // keccak256(
     // 'SetFollowModuleWithSig(uint256 profileId,address followModule,bytes followModuleData,uint256 nonce,uint256 deadline)'
     // );

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -100,6 +100,36 @@ interface ILensHub {
     function createProfile(DataTypes.CreateProfileData calldata vars) external;
 
     /**
+     * @notice Sets a the mapping between wallet and its main profile identity
+     *
+     * @param profileId The token ID of the profile to set as the main profile identity
+     */
+    function setDefaultProfile(uint256 profileId) external;
+
+    /**
+     * @notice Sets a the mapping between wallet and its main profile identity via signature with the specified parameters.
+     *
+     * @param vars A SetDefaultProfileWithSigData struct, including the regular parameters and an EIP712Signature struct.
+     */
+    function setDefaultProfileWithSig(DataTypes.SetDefaultProfileWithSigData calldata vars)
+        external;
+
+    /**
+     * @notice remove the mapping between wallet and its main profile identity
+     *
+     * @param profileId The token ID of the profile to set as the main profile identity
+     */
+    function unsetDefaultProfile(uint256 profileId) external;
+
+    /**
+     * @notice Unsets a the mapping between wallet and its main profile identity via signature with the specified parameters.
+     *
+     * @param vars A UnsetDefaultProfileWithSigData struct, including the regular parameters and an EIP712Signature struct.
+     */
+    function unsetDefaultProfileWithSig(DataTypes.UnsetDefaultProfileWithSigData calldata vars)
+        external;
+
+    /**
      * @notice Sets a profile's follow module, must be called by the profile owner.
      *
      * @param profileId The token ID of the profile to set the follow module for.
@@ -293,6 +323,15 @@ interface ILensHub {
      * @return A boolean, true if the profile creator is whitelisted.
      */
     function isProfileCreatorWhitelisted(address profileCreator) external view returns (bool);
+
+    /**
+     * @notice Returns default profile for a given wallet address
+     *
+     * @param wallet The address to find the default mapping
+     *
+     * @return A uint256 profile id will be 0 if not mapped
+     */
+    function defaultProfile(address wallet) external view returns (uint256);
 
     /**
      * @notice Returns whether or not a follow module is whitelisted.

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -103,9 +103,9 @@ interface ILensHub {
      * @notice Sets the mapping between wallet and its main profile identity
      *
      * @param profileId The token ID of the profile to set as the main profile identity
-     * @param owner The address of the wallet which owns this profileId
+     * @param wallet The address of the wallet which owns this profileId
      */
-    function setDefaultProfile(uint256 profileId, address owner) external;
+    function setDefaultProfile(uint256 profileId, address wallet) external;
 
     /**
      * @notice Sets the mapping between wallet and its main profile identity via signature with the specified parameters.

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -103,7 +103,7 @@ interface ILensHub {
      * @notice Sets the mapping between wallet and its main profile identity
      *
      * @param profileId The token ID of the profile to set as the main profile identity
-     * @param wallet The address of the wallet which owns this profileId
+     * @param wallet The address of the wallet which is either the owner of the profile or address(0)
      */
     function setDefaultProfile(uint256 profileId, address wallet) external;
 

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -103,8 +103,9 @@ interface ILensHub {
      * @notice Sets the mapping between wallet and its main profile identity
      *
      * @param profileId The token ID of the profile to set as the main profile identity
+     * @param owner The address of the wallet which owns this profileId
      */
-    function setDefaultProfile(uint256 profileId) external;
+    function setDefaultProfile(uint256 profileId, address owner) external;
 
     /**
      * @notice Sets the mapping between wallet and its main profile identity via signature with the specified parameters.
@@ -112,21 +113,6 @@ interface ILensHub {
      * @param vars A SetDefaultProfileWithSigData struct, including the regular parameters and an EIP712Signature struct.
      */
     function setDefaultProfileWithSig(DataTypes.SetDefaultProfileWithSigData calldata vars)
-        external;
-
-    /**
-     * @notice remove the mapping between wallet and its main profile identity
-     *
-     * @param profileId The token ID of the profile to set as the main profile identity
-     */
-    function unsetDefaultProfile(uint256 profileId) external;
-
-    /**
-     * @notice Unsets the mapping between wallet and its main profile identity via signature with the specified parameters.
-     *
-     * @param vars A UnsetDefaultProfileWithSigData struct, including the regular parameters and an EIP712Signature struct.
-     */
-    function unsetDefaultProfileWithSig(DataTypes.UnsetDefaultProfileWithSigData calldata vars)
         external;
 
     /**

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -100,14 +100,14 @@ interface ILensHub {
     function createProfile(DataTypes.CreateProfileData calldata vars) external;
 
     /**
-     * @notice Sets a the mapping between wallet and its main profile identity
+     * @notice Sets the mapping between wallet and its main profile identity
      *
      * @param profileId The token ID of the profile to set as the main profile identity
      */
     function setDefaultProfile(uint256 profileId) external;
 
     /**
-     * @notice Sets a the mapping between wallet and its main profile identity via signature with the specified parameters.
+     * @notice Sets the mapping between wallet and its main profile identity via signature with the specified parameters.
      *
      * @param vars A SetDefaultProfileWithSigData struct, including the regular parameters and an EIP712Signature struct.
      */
@@ -122,7 +122,7 @@ interface ILensHub {
     function unsetDefaultProfile(uint256 profileId) external;
 
     /**
-     * @notice Unsets a the mapping between wallet and its main profile identity via signature with the specified parameters.
+     * @notice Unsets the mapping between wallet and its main profile identity via signature with the specified parameters.
      *
      * @param vars A UnsetDefaultProfileWithSigData struct, including the regular parameters and an EIP712Signature struct.
      */

--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -124,18 +124,6 @@ library DataTypes {
     }
 
     /**
-     * @notice A struct containing the parameters required for the `unsetDefaultProfileWithSig()` function. Parameters are
-     * the same as the regular `unsetDefaultProfile()` function, with an added EIP712Signature.
-     *
-     * @param profileId The token ID of the profile which will be unset as default
-     * @param sig The EIP712Signature struct containing the profile owner's signature.
-     */
-    struct UnsetDefaultProfileWithSigData {
-        uint256 profileId;
-        EIP712Signature sig;
-    }
-
-    /**
      * @notice A struct containing the parameters required for the `setFollowModuleWithSig()` function. Parameters are
      * the same as the regular `setFollowModule()` function, with an added EIP712Signature.
      *

--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -110,6 +110,30 @@ library DataTypes {
     }
 
     /**
+     * @notice A struct containing the parameters required for the `setDefaultProfileWithSig()` function. Parameters are
+     * the same as the regular `setDefaultProfile()` function, with an added EIP712Signature.
+     *
+     * @param profileId The token ID of the profile which will be set as default
+     * @param sig The EIP712Signature struct containing the profile owner's signature.
+     */
+    struct SetDefaultProfileWithSigData {
+        uint256 profileId;
+        EIP712Signature sig;
+    }
+
+    /**
+     * @notice A struct containing the parameters required for the `unsetDefaultProfileWithSig()` function. Parameters are
+     * the same as the regular `unsetDefaultProfile()` function, with an added EIP712Signature.
+     *
+     * @param profileId The token ID of the profile which will be unset as default
+     * @param sig The EIP712Signature struct containing the profile owner's signature.
+     */
+    struct UnsetDefaultProfileWithSigData {
+        uint256 profileId;
+        EIP712Signature sig;
+    }
+
+    /**
      * @notice A struct containing the parameters required for the `setFollowModuleWithSig()` function. Parameters are
      * the same as the regular `setFollowModule()` function, with an added EIP712Signature.
      *

--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -114,10 +114,12 @@ library DataTypes {
      * the same as the regular `setDefaultProfile()` function, with an added EIP712Signature.
      *
      * @param profileId The token ID of the profile which will be set as default
+     * @param wallet The address of the wallet which is either the owner of the profile or address(0)
      * @param sig The EIP712Signature struct containing the profile owner's signature.
      */
     struct SetDefaultProfileWithSigData {
         uint256 profileId;
+        address wallet;
         EIP712Signature sig;
     }
 

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -139,6 +139,15 @@ library Events {
     );
 
     /**
+     * @dev Emitted when a a default profile is set for a wallet as its main identity
+     *
+     * @param profileId The token ID of the profile for which the default profile is being set.
+     * @param wallet The wallet which owns this profile
+     * @param timestamp The current block timestamp.
+     */
+    event DefaultProfileSet(uint256 indexed profileId, address indexed wallet, uint256 timestamp);
+
+    /**
      * @dev Emitted when a dispatcher is set for a specific profile.
      *
      * @param profileId The token ID of the profile for which the dispatcher is set.

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -148,6 +148,19 @@ library Events {
     event DefaultProfileSet(uint256 indexed profileId, address indexed wallet, uint256 timestamp);
 
     /**
+     * @dev Emitted when a default profile is unset for a wallet as its main identity
+     *
+     * @param unsetProfileId The token ID of the profile for which the default profile is being unset from.
+     * @param wallet The wallet which owns this profile
+     * @param timestamp The current block timestamp.
+     */
+    event DefaultProfileUnset(
+        uint256 indexed unsetProfileId,
+        address indexed wallet,
+        uint256 timestamp
+    );
+
+    /**
      * @dev Emitted when a dispatcher is set for a specific profile.
      *
      * @param profileId The token ID of the profile for which the dispatcher is set.

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -148,19 +148,6 @@ library Events {
     event DefaultProfileSet(uint256 indexed profileId, address indexed wallet, uint256 timestamp);
 
     /**
-     * @dev Emitted when a default profile is unset for a wallet as its main identity
-     *
-     * @param unsetProfileId The token ID of the profile for which the default profile is being unset from.
-     * @param wallet The wallet which owns this profile
-     * @param timestamp The current block timestamp.
-     */
-    event DefaultProfileUnset(
-        uint256 indexed unsetProfileId,
-        address indexed wallet,
-        uint256 timestamp
-    );
-
-    /**
      * @dev Emitted when a dispatcher is set for a specific profile.
      *
      * @param profileId The token ID of the profile for which the dispatcher is set.

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -1,22 +1,12 @@
+import { TransactionReceipt, TransactionResponse } from '@ethersproject/providers';
 import '@nomiclabs/hardhat-ethers';
-import {
-  BigNumberish,
-  Bytes,
-  Event,
-  logger,
-  utils,
-  BigNumber,
-  Contract,
-  ContractReceipt,
-} from 'ethers';
-import { TransactionReceipt } from '@ethersproject/providers';
+import { expect } from 'chai';
+import { BigNumber, BigNumberish, Bytes, Contract, logger, utils } from 'ethers';
 import { hexlify, keccak256, RLP, toUtf8Bytes } from 'ethers/lib/utils';
-import { TransactionResponse } from '@ethersproject/providers';
 import hre from 'hardhat';
 import { LensHub__factory } from '../../typechain-types';
-import { lensHub, LENS_HUB_NFT_NAME, helper, testWallet, eventsLib } from '../__setup.spec';
+import { eventsLib, helper, lensHub, LENS_HUB_NFT_NAME, testWallet } from '../__setup.spec';
 import { HARDHAT_CHAINID, MAX_UINT256 } from './constants';
-import { expect } from 'chai';
 
 export enum ProtocolState {
   Unpaused,
@@ -327,6 +317,16 @@ export async function getSetProfileImageURIWithSigParts(
   return await getSig(msgParams);
 }
 
+export async function getSetDefaultProfileWithSigParts(
+  profileId: BigNumberish,
+  wallet: string,
+  nonce: number,
+  deadline: string
+): Promise<{ v: number; r: string; s: string }> {
+  const msgParams = buildSetDefaultProfileWithSigParams(profileId, wallet, nonce, deadline);
+  return await getSig(msgParams);
+}
+
 export async function getSetFollowNFTURIWithSigParts(
   profileId: BigNumberish,
   followNFTURI: string,
@@ -587,6 +587,29 @@ const buildSetProfileImageURIWithSigParams = (
   value: {
     profileId: profileId,
     imageURI: imageURI,
+    nonce: nonce,
+    deadline: deadline,
+  },
+});
+
+const buildSetDefaultProfileWithSigParams = (
+  profileId: BigNumberish,
+  wallet: string,
+  nonce: number,
+  deadline: string
+) => ({
+  types: {
+    SetDefaultProfileWithSig: [
+      { name: 'profileId', type: 'uint256' },
+      { name: 'wallet', type: 'address' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ],
+  },
+  domain: domain(),
+  value: {
+    profileId: profileId,
+    wallet: wallet,
     nonce: nonce,
     deadline: deadline,
   },

--- a/test/hub/profiles/default-profile.spec.ts
+++ b/test/hub/profiles/default-profile.spec.ts
@@ -1,0 +1,52 @@
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { ZERO_ADDRESS } from '../../helpers/constants';
+import { ERRORS } from '../../helpers/errors';
+import {
+  FIRST_PROFILE_ID,
+  lensHub,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_URI,
+  userAddress,
+  userTwo,
+} from '../../__setup.spec';
+
+makeSuiteCleanRoom('Default profile Functionality', function () {
+  context('Generic', function () {
+    beforeEach(async function () {
+      await expect(
+        lensHub.createProfile({
+          to: userAddress,
+          handle: MOCK_PROFILE_HANDLE,
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+    });
+
+    context('Negatives', function () {
+      it('UserTwo should fail to set the default profile on profile owned by user 1', async function () {
+        await expect(
+          lensHub.connect(userTwo).setDefaultProfile(FIRST_PROFILE_ID)
+        ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER);
+      });
+
+      it('UserTwo should fail to change the default profile for profile one', async function () {
+        await expect(
+          lensHub.connect(userTwo).setDefaultProfile(FIRST_PROFILE_ID)
+        ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER);
+      });
+    });
+
+    context('Scenarios', function () {
+      it('User should set the default profile', async function () {
+        await expect(lensHub.setDefaultProfile(FIRST_PROFILE_ID)).to.not.be.reverted;
+        expect(await lensHub.defaultProfile(lensHub.address)).to.eq(FIRST_PROFILE_ID);
+      });
+    });
+  });
+});

--- a/test/hub/profiles/default-profile.spec.ts
+++ b/test/hub/profiles/default-profile.spec.ts
@@ -1,7 +1,8 @@
 import '@nomiclabs/hardhat-ethers';
 import { expect } from 'chai';
-import { ZERO_ADDRESS } from '../../helpers/constants';
+import { MAX_UINT256, ZERO_ADDRESS } from '../../helpers/constants';
 import { ERRORS } from '../../helpers/errors';
+import { cancelWithPermitForAll, getSetDefaultProfileWithSigParts } from '../../helpers/utils';
 import {
   FIRST_PROFILE_ID,
   lensHub,
@@ -9,8 +10,10 @@ import {
   MOCK_FOLLOW_NFT_URI,
   MOCK_PROFILE_HANDLE,
   MOCK_PROFILE_URI,
+  testWallet,
   userAddress,
   userTwo,
+  userTwoAddress,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Default profile Functionality', function () {
@@ -31,21 +34,172 @@ makeSuiteCleanRoom('Default profile Functionality', function () {
     context('Negatives', function () {
       it('UserTwo should fail to set the default profile on profile owned by user 1', async function () {
         await expect(
-          lensHub.connect(userTwo).setDefaultProfile(FIRST_PROFILE_ID)
-        ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER);
+          lensHub.connect(userTwo).setDefaultProfile(FIRST_PROFILE_ID, userTwoAddress)
+        ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER_OR_DISPATCHER);
       });
 
-      it('UserTwo should fail to change the default profile for profile one', async function () {
+      it('UserOne should fail to change the default profile for address that doesnt own the profile', async function () {
         await expect(
-          lensHub.connect(userTwo).setDefaultProfile(FIRST_PROFILE_ID)
+          lensHub.setDefaultProfile(FIRST_PROFILE_ID, userTwoAddress)
         ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER);
       });
     });
 
     context('Scenarios', function () {
       it('User should set the default profile', async function () {
-        await expect(lensHub.setDefaultProfile(FIRST_PROFILE_ID)).to.not.be.reverted;
-        expect(await lensHub.defaultProfile(lensHub.address)).to.eq(FIRST_PROFILE_ID);
+        await expect(lensHub.setDefaultProfile(FIRST_PROFILE_ID, userAddress)).to.not.be.reverted;
+        expect((await lensHub.defaultProfile(userAddress)).toNumber()).to.eq(FIRST_PROFILE_ID);
+      });
+
+      it('User should set the default profile and then be able to unset it', async function () {
+        await expect(lensHub.setDefaultProfile(FIRST_PROFILE_ID, userAddress)).to.not.be.reverted;
+        expect((await lensHub.defaultProfile(userAddress)).toNumber()).to.eq(FIRST_PROFILE_ID);
+
+        await expect(lensHub.setDefaultProfile(FIRST_PROFILE_ID, ZERO_ADDRESS)).to.not.be.reverted;
+        expect((await lensHub.defaultProfile(userAddress)).toNumber()).to.eq(0);
+      });
+    });
+  });
+
+  context('Meta-tx', function () {
+    beforeEach(async function () {
+      await expect(
+        lensHub.connect(testWallet).createProfile({
+          to: testWallet.address,
+          handle: MOCK_PROFILE_HANDLE,
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+    });
+
+    context('Negatives', function () {
+      it('TestWallet should fail to set default profile with sig with signature deadline mismatch', async function () {
+        const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
+        const { v, r, s } = await getSetDefaultProfileWithSigParts(
+          FIRST_PROFILE_ID,
+          testWallet.address,
+          nonce,
+          '0'
+        );
+
+        await expect(
+          lensHub.setDefaultProfileWithSig({
+            profileId: FIRST_PROFILE_ID,
+            wallet: testWallet.address,
+            sig: {
+              v,
+              r,
+              s,
+              deadline: MAX_UINT256,
+            },
+          })
+        ).to.be.revertedWith(ERRORS.SIGNATURE_INVALID);
+      });
+
+      it('TestWallet should fail to set default profile with sig with invalid deadline', async function () {
+        const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
+        const { v, r, s } = await getSetDefaultProfileWithSigParts(
+          FIRST_PROFILE_ID,
+          testWallet.address,
+          nonce,
+          '0'
+        );
+
+        await expect(
+          lensHub.setDefaultProfileWithSig({
+            profileId: FIRST_PROFILE_ID,
+            wallet: testWallet.address,
+            sig: {
+              v,
+              r,
+              s,
+              deadline: '0',
+            },
+          })
+        ).to.be.revertedWith(ERRORS.SIGNATURE_EXPIRED);
+      });
+
+      it('TestWallet should fail to set default profile with sig with invalid nonce', async function () {
+        const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
+        const { v, r, s } = await getSetDefaultProfileWithSigParts(
+          FIRST_PROFILE_ID,
+          testWallet.address,
+          nonce + 1,
+          MAX_UINT256
+        );
+
+        await expect(
+          lensHub.setDefaultProfileWithSig({
+            profileId: FIRST_PROFILE_ID,
+            wallet: testWallet.address,
+            sig: {
+              v,
+              r,
+              s,
+              deadline: MAX_UINT256,
+            },
+          })
+        ).to.be.revertedWith(ERRORS.SIGNATURE_INVALID);
+      });
+
+      it('TestWallet should sign attempt to set default profile with sig, cancel with empty permitForAll, then fail to set default profile with sig', async function () {
+        const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
+        const { v, r, s } = await getSetDefaultProfileWithSigParts(
+          FIRST_PROFILE_ID,
+          testWallet.address,
+          nonce,
+          MAX_UINT256
+        );
+
+        await cancelWithPermitForAll();
+
+        await expect(
+          lensHub.setDefaultProfileWithSig({
+            profileId: FIRST_PROFILE_ID,
+            wallet: testWallet.address,
+            sig: {
+              v,
+              r,
+              s,
+              deadline: MAX_UINT256,
+            },
+          })
+        ).to.be.revertedWith(ERRORS.SIGNATURE_INVALID);
+      });
+    });
+
+    context('Scenarios', function () {
+      it('TestWallet should set the default profile with sig', async function () {
+        const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
+        const { v, r, s } = await getSetDefaultProfileWithSigParts(
+          FIRST_PROFILE_ID,
+          testWallet.address,
+          nonce,
+          MAX_UINT256
+        );
+
+        const defaultProfileBeforeUse = await lensHub.defaultProfile(testWallet.address);
+
+        await expect(
+          lensHub.setDefaultProfileWithSig({
+            profileId: FIRST_PROFILE_ID,
+            wallet: testWallet.address,
+            sig: {
+              v,
+              r,
+              s,
+              deadline: MAX_UINT256,
+            },
+          })
+        ).to.not.be.reverted;
+
+        const defaultProfileAfter = await lensHub.defaultProfile(testWallet.address);
+
+        expect(defaultProfileBeforeUse.toNumber()).to.eq(0);
+        expect(defaultProfileAfter.toNumber()).to.eq(FIRST_PROFILE_ID);
       });
     });
   });


### PR DESCRIPTION
With wallet being able to follow and collect as the main ethos of this protocol you do hit some UI/UX issues when trying to display this to the users. Their wallet in theory does not hold any primary identity info about the user itself. 

This PR goes down the ethos of what ENS does as they have the same issue, you can own many ENS but you want to display a default. 

Exposing a way of allowing you to map a default profile identity to your wallet address will allow UIs ability to show the default profile when someone collects or follows if it is mapped. 

This is then adding into your web3 identity as a profile could be seen as your identity which you use throughout the web3 space. Attached to that is information about yourself which I think is super powerful. 

POC review with team and @miguelmtzinf before all clear then would write some unit tests.