### PR TITLE
Add ReFiCollectModule

### DIFF
--- a/contracts/core/modules/collect/ReFiCollectModule.sol
+++ b/contracts/core/modules/collect/ReFiCollectModule.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {ICollectModule} from '../../../interfaces/ICollectModule.sol';
+import {Errors} from '../../../libraries/Errors.sol';
+import {FeeModuleBase} from '../FeeModuleBase.sol';
+import {ModuleBase} from '../ModuleBase.sol';
+import {FollowValidationModuleBase} from '../FollowValidationModuleBase.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+
+/**
+ * @notice A struct containing the necessary data to execute collect actions on a publication.
+ *
+ * @param amount The collecting cost associated with this publication.
+ * @param recipient The recipient address associated with this publication.
+ * @param currency The currency associated with this publication.
+ * @param referralFee The referral fee associated with this publication.
+ * @param tokenToBuy The token that is bought from the collected fees. (Toucan Protocol's BCT)
+ * @param router The swap router that is used to exchange the collected fees. (UniswapV2Router02)
+ */
+struct ProfilePublicationData {
+    uint256 amount;
+    address recipient;
+    address currency;
+    uint16 referralFee;
+    address tokenToBuy;
+    address router;
+}
+
+/**
+ * @notice Necessary in order to swap tokens.
+ */
+interface IUniswapV2Router01 {
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+}
+
+/**
+ * @title ReFiCollectModule
+ * @author yakuhito
+ *
+ * @notice This is a simple Lens CollectModule implementation, extending FeeCollectModule to use all received
+ * fees to a designated address to be queued for retirement.
+ *
+ * This module works by allowing unlimited collects for a publication at a given price.
+ */
+contract ReFiCollectModule is ICollectModule, FeeModuleBase, FollowValidationModuleBase {
+    using SafeERC20 for IERC20;
+
+    mapping(uint256 => mapping(uint256 => ProfilePublicationData))
+        internal _dataByPublicationByProfile;
+
+    constructor(address hub, address moduleGlobals) FeeModuleBase(moduleGlobals) ModuleBase(hub) {}
+
+    /**
+     * @notice This collect module levies a fee on collects and supports referrals. Thus, we need to decode data.
+     *
+     * @param profileId The token ID of the profile of the publisher, passed by the hub.
+     * @param pubId The publication ID of the newly created publication, passed by the hub.
+     * @param data The arbitrary data parameter, decoded into:
+     *      uint256 amount: The currency total amount to levy.
+     *      address currency: The currency address, must be internally whitelisted.
+     *      address recipient: The custom recipient address to direct earnings to.
+     *      uint16 referralFee: The referral fee to set.
+     *
+     * @return An abi encoded bytes parameter, which is the same as the passed data parameter.
+     */
+    function initializePublicationCollectModule(
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external override onlyHub returns (bytes memory) {
+        (uint256 amount, address currency, address recipient, uint16 referralFee, address tokenToBuy, address router) = abi.decode(
+            data,
+            (uint256, address, address, uint16, address, address)
+        );
+        if (
+            !_currencyWhitelisted(currency) ||
+            !_currencyWhitelisted(tokenToBuy) ||
+            currency == tokenToBuy ||
+            recipient == address(0) ||
+            referralFee > BPS_MAX ||
+            amount < BPS_MAX
+        ) revert Errors.InitParamsInvalid();
+
+        _dataByPublicationByProfile[profileId][pubId].referralFee = referralFee;
+        _dataByPublicationByProfile[profileId][pubId].recipient = recipient;
+        _dataByPublicationByProfile[profileId][pubId].currency = currency;
+        _dataByPublicationByProfile[profileId][pubId].amount = amount;
+        _dataByPublicationByProfile[profileId][pubId].tokenToBuy = tokenToBuy;
+        _dataByPublicationByProfile[profileId][pubId].router = router;
+
+        return data;
+    }
+
+    /**
+     * @dev Processes a collect by:
+     *  1. Ensuring the collector is a follower
+     *  2. Charging a fee
+     * @dev data contains: currency (address), amount (uint256), amountOutMin (unit256)
+     */
+    function processCollect(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external virtual override onlyHub {
+        _checkFollowValidity(profileId, collector);
+        if (referrerProfileId == profileId) {
+            _processCollect(collector, profileId, pubId, data);
+        } else {
+            _processCollectWithReferral(referrerProfileId, collector, profileId, pubId, data);
+        }
+    }
+
+    /**
+     * @notice Returns the publication data for a given publication, or an empty struct if that publication was not
+     * initialized with this module.
+     *
+     * @param profileId The token ID of the profile mapped to the publication to query.
+     * @param pubId The publication ID of the publication to query.
+     *
+     * @return The ProfilePublicationData struct mapped to that publication.
+     */
+    function getPublicationData(uint256 profileId, uint256 pubId)
+        external
+        view
+        returns (ProfilePublicationData memory)
+    {
+        return _dataByPublicationByProfile[profileId][pubId];
+    }
+
+    function _processCollect(
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        (address treasury, uint16 treasuryFee) = _treasuryData();
+        uint256 treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        uint256 adjustedAmount = amount - treasuryAmount;
+        address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
+        IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
+        
+        _buyToken(collector, profileId, pubId, data);
+    }
+
+    function _processCollectWithReferral(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        uint256 referralFee = _dataByPublicationByProfile[profileId][pubId].referralFee;
+        address treasury;
+        uint256 treasuryAmount;
+
+        // Avoids stack too deep
+        {
+            uint16 treasuryFee;
+            (treasury, treasuryFee) = _treasuryData();
+            treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        }
+
+        uint256 adjustedAmount = amount - treasuryAmount;
+
+        if (referralFee != 0) {
+            // The reason we levy the referral fee on the adjusted amount is so that referral fees
+            // don't bypass the treasury fee, in essence referrals pay their fair share to the treasury.
+            uint256 referralAmount = (adjustedAmount * referralFee) / BPS_MAX;
+            adjustedAmount = adjustedAmount - referralAmount;
+
+            address referralRecipient = IERC721(HUB).ownerOf(referrerProfileId);
+
+            IERC20(currency).safeTransferFrom(collector, referralRecipient, referralAmount);
+        }
+
+        address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
+        IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
+
+        _buyToken(collector, profileId, pubId, data);
+    }
+
+    /*
+    * @dev data is already verified!
+    */
+    function _buyToken(
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        (address currency, uint256 initialAmount, uint256 amountOutMin) = abi.decode(
+            data, (address, uint256, uint256)
+        );
+        address tokenToBuy = _dataByPublicationByProfile[profileId][pubId].tokenToBuy;
+        address router = _dataByPublicationByProfile[profileId][pubId].router;
+    
+        (address treasury, uint16 treasuryFee) = _treasuryData();
+        uint256 amount = (initialAmount * treasuryFee) / BPS_MAX;
+
+        // Transfer tokens to this contract
+        IERC20(currency).safeTransferFrom(collector, address(this), amount);
+
+        // Increase allowance
+        IERC20(currency).approve(router, amount);
+
+        // Swap
+        address[] memory path = new address[](2);
+        path[0] = currency;
+        path[1] = tokenToBuy;
+        
+        IUniswapV2Router01(router).swapExactTokensForTokens(
+            amount,
+            amountOutMin,
+            path,
+            treasury,
+            block.timestamp
+        );
+    
+    }
+}

--- a/contracts/mocks/CarbonCredits.sol
+++ b/contracts/mocks/CarbonCredits.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {ERC20} from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+// Bought by the ReFiCollectModule
+contract CarbonCredits is ERC20('CarbonCredits', 'CarbonCredits') {
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/mocks/YakswapV2Router.sol
+++ b/contracts/mocks/YakswapV2Router.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+// Used by the ReFiCollectModule
+contract YakswapV2Router {
+
+    // just changes 1:1
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts) {
+        require(amountOutMin <= amountIn, "Can't give you amountOutMin");
+        require(block.timestamp <= deadline, "deadline has passed");
+
+        address fromToken = path[0];
+        address toToken = path[1];
+
+        IERC20(fromToken).transferFrom(msg.sender, address(this), amountIn);
+        IERC20(toToken).transfer(to, amountIn);
+
+        uint[] memory amounts = new uint[](2);
+        amounts[0] = amountIn;
+        amounts[1] = amountIn;
+        return amounts;
+    }
+}

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -11,6 +11,10 @@ import {
   CollectNFT__factory,
   Currency,
   Currency__factory,
+  CarbonCredits,
+  CarbonCredits__factory,
+  YakswapV2Router,
+  YakswapV2Router__factory,
   EmptyCollectModule,
   EmptyCollectModule__factory,
   Events,
@@ -38,6 +42,8 @@ import {
   ModuleGlobals,
   ModuleGlobals__factory,
   PublishingLogic__factory,
+  ReFiCollectModule,
+  ReFiCollectModule__factory,
   RevertCollectModule,
   RevertCollectModule__factory,
   TimedFeeCollectModule,
@@ -88,6 +94,8 @@ export let testWallet: Wallet;
 export let lensHubImpl: LensHub;
 export let lensHub: LensHub;
 export let currency: Currency;
+export let carbonCredits: CarbonCredits;
+export let yakswapV2Router: YakswapV2Router;
 export let abiCoder: AbiCoder;
 export let mockModuleData: BytesLike;
 export let hubLibs: LensHubLibraryAddresses;
@@ -104,6 +112,7 @@ export let emptyCollectModule: EmptyCollectModule;
 export let revertCollectModule: RevertCollectModule;
 export let limitedFeeCollectModule: LimitedFeeCollectModule;
 export let limitedTimedFeeCollectModule: LimitedTimedFeeCollectModule;
+export let reFiCollectModule: ReFiCollectModule;
 
 // Follow
 export let approvalFollowModule: ApprovalFollowModule;
@@ -188,6 +197,10 @@ before(async function () {
   // Currency
   currency = await new Currency__factory(deployer).deploy();
 
+  // ReFiCollectModule
+  carbonCredits = await new CarbonCredits__factory(deployer).deploy();
+  yakswapV2Router = await new YakswapV2Router__factory(deployer).deploy();
+
   // Modules
   emptyCollectModule = await new EmptyCollectModule__factory(deployer).deploy(lensHub.address);
   revertCollectModule = await new RevertCollectModule__factory(deployer).deploy();
@@ -204,6 +217,10 @@ before(async function () {
     moduleGlobals.address
   );
   limitedTimedFeeCollectModule = await new LimitedTimedFeeCollectModule__factory(deployer).deploy(
+    lensHub.address,
+    moduleGlobals.address
+  );
+  reFiCollectModule = await new ReFiCollectModule__factory(deployer).deploy(
     lensHub.address,
     moduleGlobals.address
   );
@@ -233,6 +250,8 @@ before(async function () {
 
   expect(lensHub).to.not.be.undefined;
   expect(currency).to.not.be.undefined;
+  expect(carbonCredits).to.not.be.undefined;
+  expect(yakswapV2Router).to.not.be.undefined;
   expect(timedFeeCollectModule).to.not.be.undefined;
   expect(mockFollowModule).to.not.be.undefined;
   expect(mockReferenceModule).to.not.be.undefined;

--- a/test/modules/collect/refi-collect-module.spec.ts
+++ b/test/modules/collect/refi-collect-module.spec.ts
@@ -1,0 +1,698 @@
+import { BigNumber } from '@ethersproject/contracts/node_modules/@ethersproject/bignumber';
+import { parseEther } from '@ethersproject/units';
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { MAX_UINT256, ZERO_ADDRESS } from '../../helpers/constants';
+import { ERRORS } from '../../helpers/errors';
+import { getTimestamp, matchEvent, waitForTx } from '../../helpers/utils';
+import {
+  abiCoder,
+  BPS_MAX,
+  currency,
+  reFiCollectModule,
+  FIRST_PROFILE_ID,
+  governance,
+  lensHub,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_URI,
+  MOCK_URI,
+  moduleGlobals,
+  REFERRAL_FEE_BPS,
+  treasuryAddress,
+  TREASURY_FEE_BPS,
+  userAddress,
+  userTwo,
+  userTwoAddress,
+  carbonCredits,
+  yakswapV2Router,
+} from '../../__setup.spec';
+
+makeSuiteCleanRoom('ReFi Collect Module', function () {
+  const DEFAULT_COLLECT_PRICE = parseEther('10');
+
+  beforeEach(async function () {
+    await expect(
+      lensHub.createProfile({
+        to: userAddress,
+        handle: MOCK_PROFILE_HANDLE,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+    await expect(
+      lensHub.connect(governance).whitelistCollectModule(reFiCollectModule.address, true)
+    ).to.not.be.reverted;
+    await expect(
+      moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)
+    ).to.not.be.reverted;
+    await expect(
+      moduleGlobals.connect(governance).whitelistCurrency(carbonCredits.address, true)
+    ).to.not.be.reverted;
+  });
+
+  context('Negatives', function () {
+    context('Publication Creation', function () {
+      it('user should fail to post with refi collect module using unwhitelisted currency', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            userTwoAddress,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with refi collect module using zero recipient', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            ZERO_ADDRESS,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with refi collect module using referral fee greater than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            10001,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with refi collect module using amount lower than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            9999,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with refi collect module using unwhitlested tokenToBuy', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            userTwoAddress,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with refi collect module setting tokenToBuy equal to currency', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            currency.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+    });
+
+    context('Collecting', function () {
+      beforeEach(async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+      });
+
+      it('UserTwo should fail to collect without following', async function () {
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.FOLLOW_INVALID);
+      });
+
+      it('UserTwo should fail to collect passing a different expected price in data', async function () {
+        await expect(
+          lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2), DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect passing a different expected currency in data', async function () {
+        await expect(
+          lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [userAddress, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect without first approving module with currency', async function () {
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+
+        await expect(
+          lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.ERC20_TRANSFER_EXCEEDS_ALLOWANCE);
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror without following the original profile', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        // const data = abiCoder.encode(['uint256'], [DEFAULT_COLLECT_PRICE]);
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(secondProfileId, 1, data)
+        ).to.be.revertedWith(ERRORS.FOLLOW_INVALID);
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected price in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(
+          lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2), DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(secondProfileId, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected currency in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(
+          lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [userAddress, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(secondProfileId, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+    });
+
+    context('Scenarios', function () {
+      it('User should post with refi collect module as the collect module and data, correct events should be emitted', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        const tx = lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: reFiCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        });
+
+        const receipt = await waitForTx(tx);
+
+        expect(receipt.logs.length).to.eq(1);
+        matchEvent(receipt, 'PostCreated', [
+          FIRST_PROFILE_ID,
+          1,
+          MOCK_URI,
+          reFiCollectModule.address,
+          [collectModuleData],
+          ZERO_ADDRESS,
+          [],
+          await getTimestamp(),
+        ]);
+      });
+
+      it('User should post with the refi collect module as the collect module and data, fetched publication data should be accurate', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+        const postTimestamp = await getTimestamp();
+
+        const fetchedData = await reFiCollectModule.getPublicationData(FIRST_PROFILE_ID, 1);
+        expect(fetchedData.amount).to.eq(DEFAULT_COLLECT_PRICE);
+        expect(fetchedData.recipient).to.eq(userAddress);
+        expect(fetchedData.currency).to.eq(currency.address);
+        expect(fetchedData.referralFee).to.eq(REFERRAL_FEE_BPS);
+        expect(fetchedData.tokenToBuy).to.eq(carbonCredits.address);
+        expect(fetchedData.router).to.eq(yakswapV2Router.address);
+      });
+
+      it('User should post with the refi collect module as the collect module and data, user two follows, then collects and pays fee, fee distribution is valid', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(carbonCredits.mint(yakswapV2Router.address, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(reFiCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+        const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .mul(TREASURY_FEE_BPS)
+          .div(BPS_MAX);
+        const expectedRecipientAmount =
+          BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+        expect(await currency.balanceOf(userTwoAddress)).to.eq(
+          BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+        );
+        expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+        expect(await carbonCredits.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+      });
+
+      it('User should post with the refi collect module as the collect module and data, user two follows, then collects twice, fee distribution is valid', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(carbonCredits.mint(yakswapV2Router.address, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(reFiCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+        const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .mul(TREASURY_FEE_BPS)
+          .div(BPS_MAX);
+        const expectedRecipientAmount =
+          BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+        expect(await currency.balanceOf(userTwoAddress)).to.eq(
+          BigNumber.from(MAX_UINT256).sub(BigNumber.from(DEFAULT_COLLECT_PRICE).mul(2))
+        );
+        expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount.mul(2));
+        expect(await carbonCredits.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount.mul(2));
+      });
+
+      it('User should post with the refi collect module as the collect module and data, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(carbonCredits.mint(yakswapV2Router.address, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(reFiCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+        const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .mul(TREASURY_FEE_BPS)
+          .div(BPS_MAX);
+        const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .sub(expectedTreasuryAmount)
+          .mul(REFERRAL_FEE_BPS)
+          .div(BPS_MAX);
+        const expectedReferrerAmount = BigNumber.from(MAX_UINT256)
+          .sub(DEFAULT_COLLECT_PRICE)
+          .add(expectedReferralAmount);
+        const expectedRecipientAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .sub(expectedTreasuryAmount)
+          .sub(expectedReferralAmount);
+
+        expect(await currency.balanceOf(userTwoAddress)).to.eq(expectedReferrerAmount);
+        expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+        expect(await carbonCredits.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+      });
+
+      it('User should post with the refi collect module as the collect module and data, with no referral fee, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16', 'address', 'address'],
+          [
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            0,
+            carbonCredits.address,
+            yakswapV2Router.address,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: reFiCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(carbonCredits.mint(yakswapV2Router.address, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(reFiCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, 0]
+        );
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+        const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .mul(TREASURY_FEE_BPS)
+          .div(BPS_MAX);
+        const expectedRecipientAmount =
+          BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+        expect(await currency.balanceOf(userTwoAddress)).to.eq(
+          BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+        );
+        expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+        expect(await carbonCredits.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+      });
+    });
+  });
+});


### PR DESCRIPTION
ReFiCollectModule - Extend the FeeCollectModule to use all received fees to buy Toucan Protocol’s BCT and send to a designated address to be queued for retirement.