### PR TITLE
Gas improvement for apps that use createProfile

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -144,6 +144,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         override
         whenNotPaused
         onlyWhitelistedProfileCreator
+        returns (uint256)
     {
         uint256 profileId = ++_profileCounter;
         _mint(vars.to, profileId);
@@ -154,6 +155,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
             _profileById,
             _followModuleWhitelisted
         );
+        return profileId;
     }
 
     /// @inheritdoc ILensHub

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -97,7 +97,7 @@ interface ILensHub {
      *      followModule: The follow module to use, can be the zero address.
      *      followModuleData: The follow module initialization data, if any
      */
-    function createProfile(DataTypes.CreateProfileData calldata vars) external;
+    function createProfile(DataTypes.CreateProfileData calldata vars) external returns (uint256 profileId);
 
     /**
      * @notice Sets a profile's follow module, must be called by the profile owner.

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -90,6 +90,8 @@ interface ILensHub {
      * @notice Creates a profile with the specified parameters, minting a profile NFT to the given recipient. This
      * function must be called by a whitelisted profile creator.
      *
+     * @return The token ID of the profile which was created.
+     *
      * @param vars A CreateProfileData struct containing the following params:
      *      to: The address receiving the profile.
      *      handle: The handle to set for the profile, must be unique and non-empty.


### PR DESCRIPTION
For protocols building on Lens, we incur more gas than we need to. We should pass the profileId in the return value.

Currently:

```
        lensHub.createProfile(createProfileData);
        uint256 profileId = lensHub.getProfileIdByHandle(createProfileData.handle);
```

Proposal which saves one external `CALL` to LensHub:


```
        uint256 profileId = lensHub.createProfile(createProfileData);
```

Example from Anno - https://github.com/liamzebedee/lens-protocol/blob/feed/contracts/core/Feed.sol#L71-L98