### PR TITLE
(wip) Downsize lenshub

### DIFF
--- a/contracts/core/FollowNFT.sol
+++ b/contracts/core/FollowNFT.sol
@@ -203,7 +203,7 @@ contract FollowNFT is LensNFTBase, IFollowNFT {
         uint256 tokenId
     ) internal override {
         address fromDelegatee = _delegates[from];
-        address toDelegatee =  _delegates[to];
+        address toDelegatee = _delegates[to];
         address followModule = ILensHub(HUB).getProfile(_profileId).followModule;
 
         _moveDelegate(fromDelegatee, toDelegatee, 1);

--- a/contracts/core/FollowNFT.sol
+++ b/contracts/core/FollowNFT.sol
@@ -191,7 +191,7 @@ contract FollowNFT is LensNFTBase, IFollowNFT {
      */
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         if (!_exists(tokenId)) revert Errors.TokenDoesNotExist();
-        return ILensHub(HUB).getFollowNFTURI(_profileId);
+        return ILensHub(HUB).getProfile(_profileId).followNFTURI;
     }
 
     /**
@@ -204,7 +204,7 @@ contract FollowNFT is LensNFTBase, IFollowNFT {
     ) internal override {
         address fromDelegatee = _delegates[from];
         address toDelegatee =  _delegates[to];
-        address followModule = ILensHub(HUB).getFollowModule(_profileId);
+        address followModule = ILensHub(HUB).getProfile(_profileId).followModule;
 
         _moveDelegate(fromDelegatee, toDelegatee, 1);
 

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -935,7 +935,8 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     }
 
     function _validateCallerIsWhitelistedProfileCreator() internal view {
-        if (!IWhitelist(_whitelist).isProfileCreatorWhitelisted(msg.sender)) revert Errors.ProfileCreatorNotWhitelisted();
+        if (!IWhitelist(_whitelist).isProfileCreatorWhitelisted(msg.sender))
+            revert Errors.ProfileCreatorNotWhitelisted();
     }
 
     function getRevision() internal pure virtual override returns (uint256) {

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -101,7 +101,8 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         _setState(newState);
     }
 
-    function setWhitelist(address newWhitelist) external onlyGov {
+    /// @inheritdoc ILensHub
+    function setWhitelist(address newWhitelist) external override onlyGov {
         _setWhitelist(newWhitelist);
     }
 

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -751,21 +751,6 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     }
 
     /// @inheritdoc ILensHub
-    function getPubCount(uint256 profileId) external view override returns (uint256) {
-        return _profileById[profileId].pubCount;
-    }
-
-    /// @inheritdoc ILensHub
-    function getFollowNFT(uint256 profileId) external view override returns (address) {
-        return _profileById[profileId].followNFT;
-    }
-
-    /// @inheritdoc ILensHub
-    function getFollowNFTURI(uint256 profileId) external view override returns (string memory) {
-        return _profileById[profileId].followNFTURI;
-    }
-
-    /// @inheritdoc ILensHub
     function getCollectNFT(uint256 profileId, uint256 pubId)
         external
         view
@@ -773,11 +758,6 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         returns (address)
     {
         return _pubByIdByProfile[profileId][pubId].collectNFT;
-    }
-
-    /// @inheritdoc ILensHub
-    function getFollowModule(uint256 profileId) external view override returns (address) {
-        return _profileById[profileId].followModule;
     }
 
     /// @inheritdoc ILensHub
@@ -798,11 +778,6 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         returns (address)
     {
         return _pubByIdByProfile[profileId][pubId].referenceModule;
-    }
-
-    /// @inheritdoc ILensHub
-    function getHandle(uint256 profileId) external view override returns (string memory) {
-        return _profileById[profileId].handle;
     }
 
     /// @inheritdoc ILensHub

--- a/contracts/core/Whitelist.sol
+++ b/contracts/core/Whitelist.sol
@@ -1,12 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pragma solidity 0.8.10;
 
 import {Errors} from '../libraries/Errors.sol';
 import {Events} from '../libraries/Events.sol';
+import {IWhitelist} from '../interfaces/IWhitelist.sol';
 
-contract Whitelist {
-    
+/**
+ * @title Whitelist
+ * @author Lens Protocol
+ *
+ * @notice This contract manages the whitelisting of modules(follow, collect, reference) and profile creators.
+ *
+ */
+contract Whitelist is IWhitelist {
     address public _governance;
-    
+
     mapping(address => bool) internal _profileCreatorWhitelisted;
     mapping(address => bool) internal _followModuleWhitelisted;
     mapping(address => bool) internal _collectModuleWhitelisted;
@@ -28,19 +37,38 @@ contract Whitelist {
     /// *****EXTERNAL VIEW FUNCTIONS*****
     /// *********************************
 
-    function isProfileCreatorWhitelisted(address profileCreator) external view returns(bool) {
+    /// @inheritdoc IWhitelist
+    function isProfileCreatorWhitelisted(address profileCreator)
+        external
+        view
+        override
+        returns (bool)
+    {
         return _profileCreatorWhitelisted[profileCreator];
     }
 
-    function isFollowModuleWhitelisted(address followModule) external view returns(bool) {
+    /// @inheritdoc IWhitelist
+    function isFollowModuleWhitelisted(address followModule) external view override returns (bool) {
         return _followModuleWhitelisted[followModule];
     }
 
-    function isCollectModuleWhitelisted(address collectModule) external view returns(bool) {
+    /// @inheritdoc IWhitelist
+    function isCollectModuleWhitelisted(address collectModule)
+        external
+        view
+        override
+        returns (bool)
+    {
         return _collectModuleWhitelisted[collectModule];
     }
 
-    function isReferenceModuleWhitelisted(address referenceModule) external view returns(bool) {
+    /// @inheritdoc IWhitelist
+    function isReferenceModuleWhitelisted(address referenceModule)
+        external
+        view
+        override
+        returns (bool)
+    {
         return _referenceModuleWhitelisted[referenceModule];
     }
 
@@ -48,35 +76,60 @@ contract Whitelist {
     /// *****GOV FUNCTIONS*****
     /// ***********************
 
+    /**
+     * @notice Sets the privileged governance role. This function can only be called by the current governance
+     * address.
+     *
+     * @param newGovernance The new governance address to set.
+     */
     function setGovernance(address newGovernance) external onlyGov {
         _setGovernance(newGovernance);
     }
 
-    function whitelistProfileCreator(address profileCreator, bool whitelist)
-        external
-        onlyGov
-    {
+    /**
+     * @notice Adds or removes a profile creator from the whitelist. This function can only be called by the current
+     * governance address.
+     *
+     * @param profileCreator The profile creator address to add or remove from the whitelist.
+     * @param whitelist Whether or not the profile creator should be whitelisted.
+     */
+    function whitelistProfileCreator(address profileCreator, bool whitelist) external onlyGov {
         _profileCreatorWhitelisted[profileCreator] = whitelist;
         emit Events.ProfileCreatorWhitelisted(profileCreator, whitelist, block.timestamp);
     }
 
+    /**
+     * @notice Adds or removes a follow module from the whitelist. This function can only be called by the current
+     * governance address.
+     *
+     * @param followModule The follow module contract address to add or remove from the whitelist.
+     * @param whitelist Whether or not the follow module should be whitelisted.
+     */
     function whitelistFollowModule(address followModule, bool whitelist) external onlyGov {
         _followModuleWhitelisted[followModule] = whitelist;
         emit Events.FollowModuleWhitelisted(followModule, whitelist, block.timestamp);
     }
 
-    function whitelistReferenceModule(address referenceModule, bool whitelist)
-        external
-        onlyGov
-    {
+    /**
+     * @notice Adds or removes a reference module from the whitelist. This function can only be called by the current
+     * governance address.
+     *
+     * @param referenceModule The reference module contract to add or remove from the whitelist.
+     * @param whitelist Whether or not the reference module should be whitelisted.
+     */
+    function whitelistReferenceModule(address referenceModule, bool whitelist) external onlyGov {
         _referenceModuleWhitelisted[referenceModule] = whitelist;
         emit Events.ReferenceModuleWhitelisted(referenceModule, whitelist, block.timestamp);
     }
 
-    function whitelistCollectModule(address collectModule, bool whitelist)
-        external
-        onlyGov
-    {
+    /**
+     * @notice Adds or removes a collect module from the whitelist. This function can only be called by the current
+     * governance address.
+     *
+     * @param collectModule The collect module contract address to add or remove from the whitelist.
+     * @param whitelist Whether or not the collect module should be whitelisted.
+     */
+    function whitelistCollectModule(address collectModule, bool whitelist) external onlyGov {
         _collectModuleWhitelisted[collectModule] = whitelist;
         emit Events.CollectModuleWhitelisted(collectModule, whitelist, block.timestamp);
     }

--- a/contracts/core/Whitelist.sol
+++ b/contracts/core/Whitelist.sol
@@ -1,0 +1,93 @@
+pragma solidity 0.8.10;
+
+import {Errors} from '../libraries/Errors.sol';
+import {Events} from '../libraries/Events.sol';
+
+contract Whitelist {
+    
+    address public _governance;
+    
+    mapping(address => bool) internal _profileCreatorWhitelisted;
+    mapping(address => bool) internal _followModuleWhitelisted;
+    mapping(address => bool) internal _collectModuleWhitelisted;
+    mapping(address => bool) internal _referenceModuleWhitelisted;
+
+    /**
+     * @dev This modifier reverts if the caller is not the configured governance address.
+     */
+    modifier onlyGov() {
+        if (msg.sender != _governance) revert Errors.NotGovernance();
+        _;
+    }
+
+    constructor(address newGovernance) {
+        _setGovernance(newGovernance);
+    }
+
+    /// *********************************
+    /// *****EXTERNAL VIEW FUNCTIONS*****
+    /// *********************************
+
+    function isProfileCreatorWhitelisted(address profileCreator) external view returns(bool) {
+        return _profileCreatorWhitelisted[profileCreator];
+    }
+
+    function isFollowModuleWhitelisted(address followModule) external view returns(bool) {
+        return _followModuleWhitelisted[followModule];
+    }
+
+    function isCollectModuleWhitelisted(address collectModule) external view returns(bool) {
+        return _collectModuleWhitelisted[collectModule];
+    }
+
+    function isReferenceModuleWhitelisted(address referenceModule) external view returns(bool) {
+        return _referenceModuleWhitelisted[referenceModule];
+    }
+
+    /// ***********************
+    /// *****GOV FUNCTIONS*****
+    /// ***********************
+
+    function setGovernance(address newGovernance) external onlyGov {
+        _setGovernance(newGovernance);
+    }
+
+    function whitelistProfileCreator(address profileCreator, bool whitelist)
+        external
+        onlyGov
+    {
+        _profileCreatorWhitelisted[profileCreator] = whitelist;
+        emit Events.ProfileCreatorWhitelisted(profileCreator, whitelist, block.timestamp);
+    }
+
+    function whitelistFollowModule(address followModule, bool whitelist) external onlyGov {
+        _followModuleWhitelisted[followModule] = whitelist;
+        emit Events.FollowModuleWhitelisted(followModule, whitelist, block.timestamp);
+    }
+
+    function whitelistReferenceModule(address referenceModule, bool whitelist)
+        external
+        onlyGov
+    {
+        _referenceModuleWhitelisted[referenceModule] = whitelist;
+        emit Events.ReferenceModuleWhitelisted(referenceModule, whitelist, block.timestamp);
+    }
+
+    function whitelistCollectModule(address collectModule, bool whitelist)
+        external
+        onlyGov
+    {
+        _collectModuleWhitelisted[collectModule] = whitelist;
+        emit Events.CollectModuleWhitelisted(collectModule, whitelist, block.timestamp);
+    }
+
+    /// ****************************
+    /// *****INTERNAL FUNCTIONS*****
+    /// ****************************
+
+    function _setGovernance(address newGovernance) internal {
+        address prevGovernance = _governance;
+        _governance = newGovernance;
+        emit Events.GovernanceSet(msg.sender, prevGovernance, newGovernance, block.timestamp);
+    }
+}

--- a/contracts/core/modules/FollowValidationModuleBase.sol
+++ b/contracts/core/modules/FollowValidationModuleBase.sol
@@ -22,11 +22,11 @@ import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
  */
 abstract contract FollowValidationModuleBase is ModuleBase {
     function _checkFollowValidity(uint256 profileId, address user) internal view {
-        address followModule = ILensHub(HUB).getFollowModule(profileId);
+        address followModule = ILensHub(HUB).getProfile(profileId).followModule;
         if (followModule != address(0)) {
             IFollowModule(followModule).validateFollow(profileId, user, 0);
         } else {
-            address followNFT = ILensHub(HUB).getFollowNFT(profileId);
+            address followNFT = ILensHub(HUB).getProfile(profileId).followNFT;
             if (followNFT == address(0)) revert Errors.FollowInvalid();
             if (IERC721(followNFT).balanceOf(user) == 0) revert Errors.FollowInvalid();
         }

--- a/contracts/core/modules/follow/FollowValidatorFollowModuleBase.sol
+++ b/contracts/core/modules/follow/FollowValidatorFollowModuleBase.sol
@@ -25,7 +25,7 @@ abstract contract FollowValidatorFollowModuleBase is IFollowModule, ModuleBase {
         address follower,
         uint256 followNFTTokenId
     ) external view override {
-        address followNFT = ILensHub(HUB).getFollowNFT(profileId);
+        address followNFT = ILensHub(HUB).getProfile(profileId).followNFT;
         if (followNFT == address(0)) revert Errors.FollowInvalid();
         if (followNFTTokenId == 0) {
             // check that follower owns a followNFT

--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -61,11 +61,6 @@ contract LensHubStorage {
     // 'CollectWithSig(uint256 profileId,uint256 pubId,bytes data,uint256 nonce,uint256 deadline)'
     // );
 
-    mapping(address => bool) internal _profileCreatorWhitelisted;
-    mapping(address => bool) internal _followModuleWhitelisted;
-    mapping(address => bool) internal _collectModuleWhitelisted;
-    mapping(address => bool) internal _referenceModuleWhitelisted;
-
     mapping(uint256 => address) internal _dispatcherByProfile;
     mapping(bytes32 => uint256) internal _profileIdByHandleHash;
     mapping(uint256 => DataTypes.ProfileStruct) internal _profileById;
@@ -77,4 +72,5 @@ contract LensHubStorage {
     uint256 internal _profileCounter;
     address internal _governance;
     address internal _emergencyAdmin;
+    address internal _whitelist;
 }

--- a/contracts/interfaces/IFollowNFT.sol
+++ b/contracts/interfaces/IFollowNFT.sol
@@ -68,5 +68,4 @@ interface IFollowNFT {
      * @param blockNumber The block number to query the delegated supply at.
      */
     function getDelegatedSupplyByBlockNumber(uint256 blockNumber) external returns (uint256);
-
 }

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -363,33 +363,6 @@ interface ILensHub {
     function getDispatcher(uint256 profileId) external view returns (address);
 
     /**
-     * @notice Returns the publication count for a given profile.
-     *
-     * @param profileId The token ID of the profile to query.
-     *
-     * @return The number of publications associated with the queried profile.
-     */
-    function getPubCount(uint256 profileId) external view returns (uint256);
-
-    /**
-     * @notice Returns the followNFT associated with a given profile, if any.
-     *
-     * @param profileId The token ID of the profile to query the followNFT for.
-     *
-     * @return The followNFT associated with the given profile.
-     */
-    function getFollowNFT(uint256 profileId) external view returns (address);
-
-    /**
-     * @notice Returns the followNFT URI associated with a given profile.
-     *
-     * @param profileId The token ID of the profile to query the followNFT URI for.
-     *
-     * @return The followNFT URI associated with the given profile.
-     */
-    function getFollowNFTURI(uint256 profileId) external view returns (string memory);
-
-    /**
      * @notice Returns the collectNFT associated with a given publication, if any.
      *
      * @param profileId The token ID of the profile that published the publication to query.
@@ -398,15 +371,6 @@ interface ILensHub {
      * @return The address of the collectNFT associated with the queried publication.
      */
     function getCollectNFT(uint256 profileId, uint256 pubId) external view returns (address);
-
-    /**
-     * @notice Returns the follow module associated witha  given profile, if any.
-     *
-     * @param profileId The token ID of the profile to query the follow module for.
-     *
-     * @return The address of the follow module associated with the given profile.
-     */
-    function getFollowModule(uint256 profileId) external view returns (address);
 
     /**
      * @notice Returns the collect module associated with a given publication.
@@ -427,15 +391,6 @@ interface ILensHub {
      * @return The address of the reference module associated with the given profile.
      */
     function getReferenceModule(uint256 profileId, uint256 pubId) external view returns (address);
-
-    /**
-     * @notice Returns the handle associated with a profile.
-     *
-     * @param profileId The token ID of the profile to query the handle for.
-     *
-     * @return The handle associated with the profile.
-     */
-    function getHandle(uint256 profileId) external view returns (string memory);
 
     /**
      * @notice Returns the publication pointer (profileId & pubId) associated with a given publication.

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -19,11 +19,13 @@ interface ILensHub {
      * @param name The name to set for the hub NFT.
      * @param symbol The symbol to set for the hub NFT.
      * @param newGovernance The governance address to set.
+     * @param newWhitelist The whitelist address to set.
      */
     function initialize(
         string calldata name,
         string calldata symbol,
-        address newGovernance
+        address newGovernance,
+        address newWhitelist
     ) external;
 
     /**
@@ -49,42 +51,6 @@ interface ILensHub {
      * @param newState The state to set, as a member of the ProtocolState enum.
      */
     function setState(DataTypes.ProtocolState newState) external;
-
-    /**
-     * @notice Adds or removes a profile creator from the whitelist. This function can only be called by the current
-     * governance address.
-     *
-     * @param profileCreator The profile creator address to add or remove from the whitelist.
-     * @param whitelist Whether or not the profile creator should be whitelisted.
-     */
-    function whitelistProfileCreator(address profileCreator, bool whitelist) external;
-
-    /**
-     * @notice Adds or removes a follow module from the whitelist. This function can only be called by the current
-     * governance address.
-     *
-     * @param followModule The follow module contract address to add or remove from the whitelist.
-     * @param whitelist Whether or not the follow module should be whitelisted.
-     */
-    function whitelistFollowModule(address followModule, bool whitelist) external;
-
-    /**
-     * @notice Adds or removes a reference module from the whitelist. This function can only be called by the current
-     * governance address.
-     *
-     * @param referenceModule The reference module contract to add or remove from the whitelist.
-     * @param whitelist Whether or not the reference module should be whitelisted.
-     */
-    function whitelistReferenceModule(address referenceModule, bool whitelist) external;
-
-    /**
-     * @notice Adds or removes a collect module from the whitelist. This function can only be called by the current
-     * governance address.
-     *
-     * @param collectModule The collect module contract address to add or remove from the whitelist.
-     * @param whitelist Whether or not the collect module should be whitelisted.
-     */
-    function whitelistCollectModule(address collectModule, bool whitelist) external;
 
     /**
      * @notice Creates a profile with the specified parameters, minting a profile NFT to the given recipient. This
@@ -302,15 +268,6 @@ interface ILensHub {
     /// ************************
 
     /**
-     * @notice Returns whether or not a profile creator is whitelisted.
-     *
-     * @param profileCreator The address of the profile creator to check.
-     *
-     * @return A boolean, true if the profile creator is whitelisted.
-     */
-    function isProfileCreatorWhitelisted(address profileCreator) external view returns (bool);
-
-    /**
      * @notice Returns default profile for a given wallet address
      *
      * @param wallet The address to find the default mapping
@@ -318,33 +275,6 @@ interface ILensHub {
      * @return A uint256 profile id will be 0 if not mapped
      */
     function defaultProfile(address wallet) external view returns (uint256);
-
-    /**
-     * @notice Returns whether or not a follow module is whitelisted.
-     *
-     * @param followModule The address of the follow module to check.
-     *
-     * @return A boolean, true if the the follow module is whitelisted.
-     */
-    function isFollowModuleWhitelisted(address followModule) external view returns (bool);
-
-    /**
-     * @notice Returns whether or not a reference module is whitelisted.
-     *
-     * @param referenceModule The address of the reference module to check.
-     *
-     * @return A boolean, true if the the reference module is whitelisted.
-     */
-    function isReferenceModuleWhitelisted(address referenceModule) external view returns (bool);
-
-    /**
-     * @notice Returns whether or not a collect module is whitelisted.
-     *
-     * @param collectModule The address of the collect module to check.
-     *
-     * @return A boolean, true if the the collect module is whitelisted.
-     */
-    function isCollectModuleWhitelisted(address collectModule) external view returns (bool);
 
     /**
      * @notice Returns the currently configured governance address.

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -53,6 +53,14 @@ interface ILensHub {
     function setState(DataTypes.ProtocolState newState) external;
 
     /**
+     * @notice Sets the whitelist contract address. This function
+     * can only be called by the governance address.
+     *
+     * @param newWhitelist The new whitelist contract address to set.
+     */
+    function setWhitelist(address newWhitelist) external;
+
+    /**
      * @notice Creates a profile with the specified parameters, minting a profile NFT to the given recipient. This
      * function must be called by a whitelisted profile creator.
      *

--- a/contracts/interfaces/IWhitelist.sol
+++ b/contracts/interfaces/IWhitelist.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+interface IWhitelist {
+    function isProfileCreatorWhitelisted(address profileCreator) external view returns(bool);
+    function isFollowModuleWhitelisted(address followModule) external view returns(bool);
+    function isCollectModuleWhitelisted(address collectModule) external view returns(bool);
+    function isReferenceModuleWhitelisted(address referenceModule) external view returns(bool);
+}

--- a/contracts/interfaces/IWhitelist.sol
+++ b/contracts/interfaces/IWhitelist.sol
@@ -2,9 +2,46 @@
 
 pragma solidity 0.8.10;
 
+/**
+ * @title IWhitelist
+ * @author Lens Protocol
+ *
+ * @notice This is the interface for the Whitelist contract, which acts as a helper to whitelist actors and modules.
+ */
 interface IWhitelist {
-    function isProfileCreatorWhitelisted(address profileCreator) external view returns(bool);
-    function isFollowModuleWhitelisted(address followModule) external view returns(bool);
-    function isCollectModuleWhitelisted(address collectModule) external view returns(bool);
-    function isReferenceModuleWhitelisted(address referenceModule) external view returns(bool);
+    /**
+     * @notice Returns whether or not a profile creator is whitelisted.
+     *
+     * @param profileCreator The address of the profile creator to check.
+     *
+     * @return A boolean, true if the profile creator is whitelisted.
+     */
+    function isProfileCreatorWhitelisted(address profileCreator) external view returns (bool);
+
+    /**
+     * @notice Returns whether or not a follow module is whitelisted.
+     *
+     * @param followModule The address of the follow module to check.
+     *
+     * @return A boolean, true if the the follow module is whitelisted.
+     */
+    function isFollowModuleWhitelisted(address followModule) external view returns (bool);
+
+    /**
+     * @notice Returns whether or not a collect module is whitelisted.
+     *
+     * @param collectModule The address of the collect module to check.
+     *
+     * @return A boolean, true if the the collect module is whitelisted.
+     */
+    function isCollectModuleWhitelisted(address collectModule) external view returns (bool);
+
+    /**
+     * @notice Returns whether or not a reference module is whitelisted.
+     *
+     * @param referenceModule The address of the reference module to check.
+     *
+     * @return A boolean, true if the the reference module is whitelisted.
+     */
+    function isReferenceModuleWhitelisted(address referenceModule) external view returns (bool);
 }

--- a/contracts/libraries/PublishingLogic.sol
+++ b/contracts/libraries/PublishingLogic.sol
@@ -35,7 +35,7 @@ library PublishingLogic {
      * @param profileId The profile ID to associate with this profile NFT (token ID).
      * @param _profileIdByHandleHash The storage reference to the mapping of profile IDs by handle hash.
      * @param _profileById The storage reference to the mapping of profile structs by IDs.
-     * @param whitelist The storage reference to the mapping of whitelist status by follow module address.
+     * @param whitelist address of the whitelisting contract
      */
     function createProfile(
         DataTypes.CreateProfileData calldata vars,
@@ -76,7 +76,7 @@ library PublishingLogic {
      * @param followModule The follow module to set for the given profile, if any.
      * @param followModuleData The data to pass to the follow module for profile initialization.
      * @param _profile The storage reference to the profile struct associated with the given profile ID.
-     * @param whitelist The storage reference to the mapping of whitelist status by follow module address.
+     * @param whitelist address of the whitelisting contract
      */
     function setFollowModule(
         uint256 profileId,
@@ -117,7 +117,7 @@ library PublishingLogic {
      * @param referenceModuleData The data to pass to the reference module for publication initialization.
      * @param pubId The publication ID to associate with this publication.
      * @param _pubByIdByProfile The storage reference to the mapping of publications by publication ID by profile ID.
-     * @param whitelist The storage reference to the mapping of whitelist status by collect module address.
+     * @param whitelist address of the whitelisting contract
      */
     function createPost(
         uint256 profileId,
@@ -175,7 +175,7 @@ library PublishingLogic {
      * @param pubId The publication ID to associate with this publication.
      * @param _profileById The storage reference to the mapping of profile structs by IDs.
      * @param _pubByIdByProfile The storage reference to the mapping of publications by publication ID by profile ID.
-     * @param whitelist The storage reference to the mapping of whitelist status by collect module address.
+     * @param whitelist address of the whitelisting contract
      */
     function createComment(
         DataTypes.CommentData memory vars,
@@ -239,7 +239,7 @@ library PublishingLogic {
      * @param referenceModuleData The data to pass to the reference module for publication initialization.
      * @param pubId The publication ID to associate with this publication.
      * @param _pubByIdByProfile The storage reference to the mapping of publications by publication ID by profile ID.
-     * @param whitelist The storage reference to the mapping of whitelist status by reference module address.
+     * @param whitelist address of the whitelisting contract
      */
     function createMirror(
         uint256 profileId,
@@ -302,7 +302,8 @@ library PublishingLogic {
             storage _pubByIdByProfile,
         address whitelist
     ) private returns (bytes memory) {
-        if (!IWhitelist(whitelist).isCollectModuleWhitelisted(collectModule)) revert Errors.CollectModuleNotWhitelisted();
+        if (!IWhitelist(whitelist).isCollectModuleWhitelisted(collectModule))
+            revert Errors.CollectModuleNotWhitelisted();
         _pubByIdByProfile[profileId][pubId].collectModule = collectModule;
         return
             ICollectModule(collectModule).initializePublicationCollectModule(
@@ -343,7 +344,8 @@ library PublishingLogic {
         address whitelist
     ) private returns (bytes memory) {
         if (followModule != address(0)) {
-            if (!IWhitelist(whitelist).isFollowModuleWhitelisted(followModule)) revert Errors.FollowModuleNotWhitelisted();
+            if (!IWhitelist(whitelist).isFollowModuleWhitelisted(followModule))
+                revert Errors.FollowModuleNotWhitelisted();
             bytes memory returnData = IFollowModule(followModule).initializeFollowModule(
                 profileId,
                 followModuleData

--- a/contracts/upgradeability/TransparentUpgradeableProxy.sol
+++ b/contracts/upgradeability/TransparentUpgradeableProxy.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import '@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol';
 
 /**
  * NOTE: This is a direct copy of OpenZeppelin's TransparentUpgradeableProxy and is only present for
@@ -39,7 +39,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
         address admin_,
         bytes memory _data
     ) payable ERC1967Proxy(_logic, _data) {
-        assert(_ADMIN_SLOT == bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1));
+        assert(_ADMIN_SLOT == bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1));
         _changeAdmin(admin_);
     }
 
@@ -97,7 +97,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
      */
     function upgradeTo(address newImplementation) external ifAdmin {
-        _upgradeToAndCall(newImplementation, bytes(""), false);
+        _upgradeToAndCall(newImplementation, bytes(''), false);
     }
 
     /**
@@ -107,7 +107,11 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      *
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
      */
-    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable ifAdmin {
+    function upgradeToAndCall(address newImplementation, bytes calldata data)
+        external
+        payable
+        ifAdmin
+    {
         _upgradeToAndCall(newImplementation, data, true);
     }
 
@@ -122,7 +126,10 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
      */
     function _beforeFallback() internal virtual override {
-        require(msg.sender != _getAdmin(), "TransparentUpgradeableProxy: admin cannot fallback to proxy target");
+        require(
+            msg.sender != _getAdmin(),
+            'TransparentUpgradeableProxy: admin cannot fallback to proxy target'
+        );
         super._beforeFallback();
     }
 }

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -162,7 +162,8 @@ before(async function () {
   // nonce + 0 is follow NFT impl
   // nonce + 1 is collect NFT impl
   // nonce + 2 is impl
-  // nonce + 3 is hub proxy
+  // nonce + 3 is whitelist contract
+  // nonce + 4 is hub proxy
 
   const hubProxyAddress = computeContractAddress(deployerAddress, nonce + 4); //'0x' + keccak256(RLP.encode([deployerAddress, hubProxyNonce])).substr(26);
 

--- a/test/hub/interactions/collecting.spec.ts
+++ b/test/hub/interactions/collecting.spec.ts
@@ -23,12 +23,13 @@ import {
   userTwo,
   userTwoAddress,
   MOCK_FOLLOW_NFT_URI,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Collecting', function () {
   beforeEach(async function () {
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       lensHub.createProfile({

--- a/test/hub/interactions/collecting.spec.ts
+++ b/test/hub/interactions/collecting.spec.ts
@@ -62,7 +62,7 @@ makeSuiteCleanRoom('Collecting', function () {
 
       it('user two should follow, then transfer the followNFT and fail to collect', async function () {
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
-        const followNftAddr = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNftAddr = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
         await expect(
           FollowNFT__factory.connect(followNftAddr, userTwo).transferFrom(
             userTwoAddress,

--- a/test/hub/interactions/following.spec.ts
+++ b/test/hub/interactions/following.spec.ts
@@ -63,7 +63,7 @@ makeSuiteCleanRoom('Following', function () {
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const timestamp = await getTimestamp();
 
-        const followNFTAddress = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNFTAddress = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
         const followNFT = FollowNFT__factory.connect(followNFTAddress, user);
         expect(followNFT.address).to.not.eq(ZERO_ADDRESS);
         const id = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 0);
@@ -87,7 +87,7 @@ makeSuiteCleanRoom('Following', function () {
       it('UserTwo should follow profile 1 twice, receiving followNFTs with IDs 1 and 2', async function () {
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
-        const followNFTAddress = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNFTAddress = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
         const followNFT = FollowNFT__factory.connect(followNFTAddress, user);
         const idOne = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 0);
         const idTwo = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 1);
@@ -97,7 +97,7 @@ makeSuiteCleanRoom('Following', function () {
 
       it('UserTwo should follow profile 1 3 times in the same call, receive IDs 1,2 and 3', async function () {
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID, FIRST_PROFILE_ID, FIRST_PROFILE_ID], [[], [], []])).to.not.be.reverted;
-        const followNFTAddress = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNFTAddress = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
         const followNFT = FollowNFT__factory.connect(followNFTAddress, user);
         const idOne = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 0);
         const idTwo = await followNFT.tokenOfOwnerByIndex(userTwoAddress, 1);
@@ -250,7 +250,7 @@ makeSuiteCleanRoom('Following', function () {
           })
         ).to.not.be.reverted;
 
-        const followNFTAddress = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNFTAddress = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
         const followNFT = FollowNFT__factory.connect(followNFTAddress, user);
         const id = await followNFT.tokenOfOwnerByIndex(testWallet.address, 0);
         expect(id).to.eq(1);
@@ -284,7 +284,7 @@ makeSuiteCleanRoom('Following', function () {
           })
         ).to.not.be.reverted;
 
-        const followNFTAddress = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNFTAddress = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
         const followNFT = FollowNFT__factory.connect(followNFTAddress, user);
         const idOne = await followNFT.tokenOfOwnerByIndex(testWallet.address, 0);
         const idTwo = await followNFT.tokenOfOwnerByIndex(testWallet.address, 1);

--- a/test/hub/interactions/governance.spec.ts
+++ b/test/hub/interactions/governance.spec.ts
@@ -1,19 +1,20 @@
 import '@nomiclabs/hardhat-ethers';
 import { expect } from 'chai';
 import { ERRORS } from '../../helpers/errors';
-import { governance, lensHub, makeSuiteCleanRoom, userAddress } from '../../__setup.spec';
+import { governance, makeSuiteCleanRoom, userAddress, whitelist } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Governance Functions', function () {
   context('Negatives', function () {
     it('User should not be able to call governance functions', async function () {
-      await expect(lensHub.setGovernance(userAddress)).to.be.revertedWith(ERRORS.NOT_GOVERNANCE);
-      await expect(lensHub.whitelistFollowModule(userAddress, true)).to.be.revertedWith(
+      await expect(whitelist.setGovernance(userAddress)).to.be.revertedWith(ERRORS.NOT_GOVERNANCE);
+      console.log(await whitelist._governance);
+      await expect(whitelist.whitelistFollowModule(userAddress, true)).to.be.revertedWith(
         ERRORS.NOT_GOVERNANCE
       );
-      await expect(lensHub.whitelistReferenceModule(userAddress, true)).to.be.revertedWith(
+      await expect(whitelist.whitelistReferenceModule(userAddress, true)).to.be.revertedWith(
         ERRORS.NOT_GOVERNANCE
       );
-      await expect(lensHub.whitelistCollectModule(userAddress, true)).to.be.revertedWith(
+      await expect(whitelist.whitelistCollectModule(userAddress, true)).to.be.revertedWith(
         ERRORS.NOT_GOVERNANCE
       );
     });
@@ -22,34 +23,34 @@ makeSuiteCleanRoom('Governance Functions', function () {
   context('Scenarios', function () {
     it('Governance should successfully whitelist and unwhitelist modules', async function () {
       await expect(
-        lensHub.connect(governance).whitelistFollowModule(userAddress, true)
+        whitelist.connect(governance).whitelistFollowModule(userAddress, true)
       ).to.not.be.reverted;
       await expect(
-        lensHub.connect(governance).whitelistReferenceModule(userAddress, true)
+        whitelist.connect(governance).whitelistReferenceModule(userAddress, true)
       ).to.not.be.reverted;
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(userAddress, true)
+        whitelist.connect(governance).whitelistCollectModule(userAddress, true)
       ).to.not.be.reverted;
-      expect(await lensHub.isFollowModuleWhitelisted(userAddress)).to.eq(true);
-      expect(await lensHub.isReferenceModuleWhitelisted(userAddress)).to.eq(true);
-      expect(await lensHub.isCollectModuleWhitelisted(userAddress)).to.eq(true);
+      expect(await whitelist.isFollowModuleWhitelisted(userAddress)).to.eq(true);
+      expect(await whitelist.isReferenceModuleWhitelisted(userAddress)).to.eq(true);
+      expect(await whitelist.isCollectModuleWhitelisted(userAddress)).to.eq(true);
 
       await expect(
-        lensHub.connect(governance).whitelistFollowModule(userAddress, false)
+        whitelist.connect(governance).whitelistFollowModule(userAddress, false)
       ).to.not.be.reverted;
       await expect(
-        lensHub.connect(governance).whitelistReferenceModule(userAddress, false)
+        whitelist.connect(governance).whitelistReferenceModule(userAddress, false)
       ).to.not.be.reverted;
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(userAddress, false)
+        whitelist.connect(governance).whitelistCollectModule(userAddress, false)
       ).to.not.be.reverted;
-      expect(await lensHub.isFollowModuleWhitelisted(userAddress)).to.eq(false);
-      expect(await lensHub.isReferenceModuleWhitelisted(userAddress)).to.eq(false);
-      expect(await lensHub.isCollectModuleWhitelisted(userAddress)).to.eq(false);
+      expect(await whitelist.isFollowModuleWhitelisted(userAddress)).to.eq(false);
+      expect(await whitelist.isReferenceModuleWhitelisted(userAddress)).to.eq(false);
+      expect(await whitelist.isCollectModuleWhitelisted(userAddress)).to.eq(false);
     });
 
     it('Governance should successfully change the governance address', async function () {
-      await expect(lensHub.connect(governance).setGovernance(userAddress)).to.not.be.reverted;
+      await expect(whitelist.connect(governance).setGovernance(userAddress)).to.not.be.reverted;
     });
   });
 });

--- a/test/hub/interactions/multi-state-hub.spec.ts
+++ b/test/hub/interactions/multi-state-hub.spec.ts
@@ -27,6 +27,7 @@ import {
   testWallet,
   userAddress,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Multi-State Hub', function () {
@@ -459,7 +460,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         await expect(lensHub.connect(governance).setState(ProtocolState.Paused)).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -504,7 +505,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         await expect(lensHub.connect(governance).setState(ProtocolState.Paused)).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -574,7 +575,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -634,7 +635,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -723,7 +724,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -777,7 +778,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -958,7 +959,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -998,7 +999,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -1277,7 +1278,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -1324,7 +1325,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -1394,7 +1395,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -1456,7 +1457,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -1547,7 +1548,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -1603,7 +1604,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -1762,7 +1763,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -1798,7 +1799,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(

--- a/test/hub/interactions/publishing-comments.spec.ts
+++ b/test/hub/interactions/publishing-comments.spec.ts
@@ -20,6 +20,7 @@ import {
   timedFeeCollectModule,
   userAddress,
   userTwo,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Publishing Comments', function () {
@@ -37,15 +38,15 @@ makeSuiteCleanRoom('Publishing Comments', function () {
       ).to.not.be.reverted;
 
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(timedFeeCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(timedFeeCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
-        lensHub.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
+        whitelist.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -219,7 +220,7 @@ makeSuiteCleanRoom('Publishing Comments', function () {
       ).to.not.be.reverted;
 
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -389,7 +390,7 @@ makeSuiteCleanRoom('Publishing Comments', function () {
 
       it('TestWallet should fail to comment with sig with unwhitelisted reference module', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -431,7 +432,7 @@ makeSuiteCleanRoom('Publishing Comments', function () {
 
       it('TestWallet should fail to comment with sig on a publication that does not exist', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -473,7 +474,7 @@ makeSuiteCleanRoom('Publishing Comments', function () {
 
       it('TestWallet should sign attempt to comment with sig, cancel via empty permitForAll, then fail to comment with sig', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -519,7 +520,7 @@ makeSuiteCleanRoom('Publishing Comments', function () {
     context('Scenarios', function () {
       it('TestWallet should comment with sig, fetched comment data should be accurate', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();

--- a/test/hub/interactions/publishing-mirrors.spec.ts
+++ b/test/hub/interactions/publishing-mirrors.spec.ts
@@ -18,6 +18,7 @@ import {
   testWallet,
   userAddress,
   userTwo,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Publishing mirrors', function () {
@@ -35,11 +36,11 @@ makeSuiteCleanRoom('Publishing mirrors', function () {
       ).to.not.be.reverted;
 
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
-        lensHub.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
+        whitelist.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -195,7 +196,7 @@ makeSuiteCleanRoom('Publishing mirrors', function () {
       ).to.not.be.reverted;
 
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(

--- a/test/hub/interactions/publishing-posts.spec.ts
+++ b/test/hub/interactions/publishing-posts.spec.ts
@@ -19,6 +19,7 @@ import {
   timedFeeCollectModule,
   userAddress,
   userTwo,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Publishing Posts', function () {
@@ -65,7 +66,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('User should fail to post with an unwhitelisted reference module', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -82,7 +83,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('User should fail to post with invalid collect module data format', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(timedFeeCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(timedFeeCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -99,11 +100,11 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('User should fail to post with invalid reference module data format', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
-          lensHub.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
+          whitelist.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -122,7 +123,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
     context('Scenarios', function () {
       it('User should create a post with empty collect and reference module data, fetched post data should be accurate', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -147,10 +148,10 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('User should create a post with a whitelisted collect and reference module', async function () {
         await expect(
-          lensHub.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
+          whitelist.connect(governance).whitelistReferenceModule(mockReferenceModule.address, true)
         ).to.not.be.reverted;
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -184,7 +185,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
     context('Negatives', function () {
       it('Testwallet should fail to post with sig with signature deadline mismatch', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -222,7 +223,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('Testwallet should fail to post with sig with invalid deadline', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -260,7 +261,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('Testwallet should fail to post with sig with invalid nonce', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -332,7 +333,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('Testwallet should fail to post with sig with an unwhitelisted reference module', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -370,7 +371,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
 
       it('TestWallet should sign attempt to post with sig, cancel via empty permitForAll, then fail to post with sig', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -412,7 +413,7 @@ makeSuiteCleanRoom('Publishing Posts', function () {
     context('Scenarios', function () {
       it('TestWallet should post with sig, fetched post data should be accurate', async function () {
         await expect(
-          lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+          whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();

--- a/test/hub/profiles/dispatcher.spec.ts
+++ b/test/hub/profiles/dispatcher.spec.ts
@@ -17,6 +17,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Dispatcher Functionality', function () {
@@ -33,7 +34,7 @@ makeSuiteCleanRoom('Dispatcher Functionality', function () {
         })
       ).to.not.be.reverted;
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
     });
 
@@ -119,7 +120,7 @@ makeSuiteCleanRoom('Dispatcher Functionality', function () {
         })
       ).to.not.be.reverted;
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
     });
 

--- a/test/hub/profiles/profile-creation.spec.ts
+++ b/test/hub/profiles/profile-creation.spec.ts
@@ -18,6 +18,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Profile Creation', function () {
@@ -92,7 +93,7 @@ makeSuiteCleanRoom('Profile Creation', function () {
 
       it('User should fail to create a profile with with invalid follow module data format', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -109,7 +110,7 @@ makeSuiteCleanRoom('Profile Creation', function () {
 
       it('User should fail to createa a profile when they are not a whitelisted profile creator', async function () {
         await expect(
-          lensHub.connect(governance).whitelistProfileCreator(userAddress, false)
+          whitelist.connect(governance).whitelistProfileCreator(userAddress, false)
         ).to.not.be.reverted;
 
         await expect(
@@ -219,7 +220,7 @@ makeSuiteCleanRoom('Profile Creation', function () {
 
       it('User should be able to create a profile with a whitelisted follow module', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         await expect(

--- a/test/hub/profiles/profile-uri.spec.ts
+++ b/test/hub/profiles/profile-uri.spec.ts
@@ -69,7 +69,7 @@ makeSuiteCleanRoom('Profile URI Functionality', function () {
 
       it('User should follow profile 1, user should change the follow NFT URI, URI is accurate before and after the change', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
-        const followNFTAddress = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+        const followNFTAddress = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
         const followNFT = FollowNFT__factory.connect(followNFTAddress, user);
 
         const uriBefore = await followNFT.tokenURI(1);
@@ -327,7 +327,7 @@ makeSuiteCleanRoom('Profile URI Functionality', function () {
           MAX_UINT256
         );
 
-        const followNFTURIBefore = await lensHub.getFollowNFTURI(FIRST_PROFILE_ID);
+        const followNFTURIBefore = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFTURI;
 
         await expect(
           lensHub.setFollowNFTURIWithSig({
@@ -342,7 +342,7 @@ makeSuiteCleanRoom('Profile URI Functionality', function () {
           })
         ).to.not.be.reverted;
 
-        const followNFTURIAfter = await lensHub.getFollowNFTURI(FIRST_PROFILE_ID);
+        const followNFTURIAfter = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFTURI;
 
         expect(followNFTURIBefore).to.eq(MOCK_FOLLOW_NFT_URI);
         expect(followNFTURIAfter).to.eq(MOCK_URI);

--- a/test/hub/profiles/setting-follow-module.spec.ts
+++ b/test/hub/profiles/setting-follow-module.spec.ts
@@ -16,6 +16,7 @@ import {
   testWallet,
   userAddress,
   userTwo,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Setting Follow Module', function () {
@@ -48,7 +49,7 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
 
       it('User should fail to set a follow module with invalid follow module data format', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -60,7 +61,7 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
     context('Scenarios', function () {
       it('User should set a whitelisted follow module, fetching the profile follow module should return the correct address, user then sets it to the zero address and fetching returns the zero address', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         await expect(
@@ -95,7 +96,7 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
     context('Negatives', function () {
       it('TestWallet should fail to set a follow module with sig with signature deadline mismatch', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -126,7 +127,7 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
 
       it('TestWallet should fail to set a follow module with sig with invalid deadline', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -157,7 +158,7 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
 
       it('TestWallet should fail to set a follow module with sig with invalid nonce', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -215,7 +216,7 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
 
       it('TestWallet should sign attempt to set follow module with sig, then cancel with empty permitForAll, then fail to set follow module with sig', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();
@@ -249,7 +250,7 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
     context('Scenarios', function () {
       it('TestWallet should set a whitelisted follow module with sig, fetching the profile follow module should return the correct address', async function () {
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
         ).to.not.be.reverted;
 
         const nonce = (await lensHub.sigNonces(testWallet.address)).toNumber();

--- a/test/hub/profiles/setting-follow-module.spec.ts
+++ b/test/hub/profiles/setting-follow-module.spec.ts
@@ -66,12 +66,14 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
         await expect(
           lensHub.setFollowModule(FIRST_PROFILE_ID, mockFollowModule.address, mockModuleData)
         ).to.not.be.reverted;
-        expect(await lensHub.getFollowModule(FIRST_PROFILE_ID)).to.eq(mockFollowModule.address);
+        expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followModule).to.eq(
+          mockFollowModule.address
+        );
 
         await expect(
           lensHub.setFollowModule(FIRST_PROFILE_ID, ZERO_ADDRESS, [])
         ).to.not.be.reverted;
-        expect(await lensHub.getFollowModule(FIRST_PROFILE_ID)).to.eq(ZERO_ADDRESS);
+        expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followModule).to.eq(ZERO_ADDRESS);
       });
     });
   });
@@ -274,7 +276,9 @@ makeSuiteCleanRoom('Setting Follow Module', function () {
           })
         ).to.not.be.reverted;
 
-        expect(await lensHub.getFollowModule(FIRST_PROFILE_ID)).to.eq(mockFollowModule.address);
+        expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followModule).to.eq(
+          mockFollowModule.address
+        );
       });
     });
   });

--- a/test/modules/collect/empty-collect-module.spec.ts
+++ b/test/modules/collect/empty-collect-module.spec.ts
@@ -17,6 +17,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Empty Collect Module', function () {
@@ -32,7 +33,7 @@ makeSuiteCleanRoom('Empty Collect Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       lensHub.post({
@@ -84,7 +85,7 @@ makeSuiteCleanRoom('Empty Collect Module', function () {
       it('UserTwo should mirror the original post, fail to collect from their mirror without following the original profile when it has a follow module set', async function () {
         const secondProfileId = FIRST_PROFILE_ID + 1;
         await expect(
-          lensHub.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
+          whitelist.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
         ).to.not.be.reverted;
         await expect(
           lensHub.setFollowModule(FIRST_PROFILE_ID, approvalFollowModule.address, [])
@@ -124,7 +125,7 @@ makeSuiteCleanRoom('Empty Collect Module', function () {
 
     it('UserTwo should collect with success when following according the follow module set', async function () {
       await expect(
-        lensHub.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
+        whitelist.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
       ).to.not.be.reverted;
       await expect(
         lensHub.setFollowModule(FIRST_PROFILE_ID, approvalFollowModule.address, [])
@@ -165,7 +166,7 @@ makeSuiteCleanRoom('Empty Collect Module', function () {
     it('UserTwo should mirror the original post, collect with success from their mirror when following the original profile which has a follow module set', async function () {
       const secondProfileId = FIRST_PROFILE_ID + 1;
       await expect(
-        lensHub.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
+        whitelist.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
       ).to.not.be.reverted;
       await expect(
         lensHub.setFollowModule(FIRST_PROFILE_ID, approvalFollowModule.address, [])

--- a/test/modules/collect/fee-collect-module.spec.ts
+++ b/test/modules/collect/fee-collect-module.spec.ts
@@ -25,6 +25,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Fee Collect Module', function () {
@@ -42,7 +43,7 @@ makeSuiteCleanRoom('Fee Collect Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(feeCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(feeCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)

--- a/test/modules/collect/limited-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-fee-collect-module.spec.ts
@@ -25,6 +25,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Limited Fee Collect Module', function () {
@@ -43,7 +44,7 @@ makeSuiteCleanRoom('Limited Fee Collect Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(limitedFeeCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(limitedFeeCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)

--- a/test/modules/collect/limited-timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-timed-fee-collect-module.spec.ts
@@ -25,6 +25,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Limited Timed Fee Collect Module', function () {
@@ -43,7 +44,7 @@ makeSuiteCleanRoom('Limited Timed Fee Collect Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(limitedTimedFeeCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(limitedTimedFeeCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)

--- a/test/modules/collect/revert-collect-module.spec.ts
+++ b/test/modules/collect/revert-collect-module.spec.ts
@@ -15,6 +15,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Revert Collect Module', function () {
@@ -30,7 +31,7 @@ makeSuiteCleanRoom('Revert Collect Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(revertCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(revertCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       lensHub.post({

--- a/test/modules/collect/timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/timed-fee-collect-module.spec.ts
@@ -25,6 +25,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Timed Fee Collect Module', function () {
@@ -42,7 +43,7 @@ makeSuiteCleanRoom('Timed Fee Collect Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(timedFeeCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(timedFeeCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)

--- a/test/modules/follow/approval-follow-module.spec.ts
+++ b/test/modules/follow/approval-follow-module.spec.ts
@@ -18,6 +18,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Approval Follow Module', function () {
@@ -33,7 +34,7 @@ makeSuiteCleanRoom('Approval Follow Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
+      whitelist.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
     ).to.not.be.reverted;
   });
 

--- a/test/modules/follow/fee-follow-module.spec.ts
+++ b/test/modules/follow/fee-follow-module.spec.ts
@@ -24,6 +24,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Fee Follow Module', function () {
@@ -31,7 +32,7 @@ makeSuiteCleanRoom('Fee Follow Module', function () {
 
   beforeEach(async function () {
     await expect(
-      lensHub.connect(governance).whitelistFollowModule(feeFollowModule.address, true)
+      whitelist.connect(governance).whitelistFollowModule(feeFollowModule.address, true)
     ).to.not.be.reverted;
     await expect(
       moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)

--- a/test/modules/reference/follower-only-reference-module.spec.ts
+++ b/test/modules/reference/follower-only-reference-module.spec.ts
@@ -19,6 +19,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../../__setup.spec';
 
 makeSuiteCleanRoom('Follower Only Reference Module', function () {
@@ -34,12 +35,12 @@ makeSuiteCleanRoom('Follower Only Reference Module', function () {
       })
     ).to.not.be.reverted;
     await expect(
-      lensHub
+      whitelist
         .connect(governance)
         .whitelistReferenceModule(followerOnlyReferenceModule.address, true)
     ).to.not.be.reverted;
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       lensHub.post({

--- a/test/modules/reference/follower-only-reference-module.spec.ts
+++ b/test/modules/reference/follower-only-reference-module.spec.ts
@@ -74,7 +74,7 @@ makeSuiteCleanRoom('Follower Only Reference Module', function () {
       it('Commenting should fail if commenter follows, then transfers the follow NFT before attempting to comment', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -111,7 +111,7 @@ makeSuiteCleanRoom('Follower Only Reference Module', function () {
       it('Mirroring should fail if publisher follows, then transfers the follow NFT before attempting to mirror', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -161,7 +161,7 @@ makeSuiteCleanRoom('Follower Only Reference Module', function () {
       it('Commenting should work if the commenter is a follower', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -182,7 +182,7 @@ makeSuiteCleanRoom('Follower Only Reference Module', function () {
       it('Commenting should work if the commenter follows, transfers the follow NFT then receives it back before attempting to comment', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -211,7 +211,7 @@ makeSuiteCleanRoom('Follower Only Reference Module', function () {
       it('Mirroring should work if publisher is a follower', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -229,7 +229,7 @@ makeSuiteCleanRoom('Follower Only Reference Module', function () {
       it('Mirroring should work if publisher follows, transfers the follow NFT then receives it back before attempting to mirror', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 

--- a/test/nft/collect-nft.spec.ts
+++ b/test/nft/collect-nft.spec.ts
@@ -16,13 +16,14 @@ import {
   user,
   userAddress,
   userTwo,
+  whitelist,
 } from '../__setup.spec';
 
 makeSuiteCleanRoom('Collect NFT', function () {
   let collectNFT: CollectNFT;
   beforeEach(async function () {
     await expect(
-      lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+      whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
     ).to.not.be.reverted;
     await expect(
       lensHub.createProfile({

--- a/test/nft/follow-nft.spec.ts
+++ b/test/nft/follow-nft.spec.ts
@@ -45,7 +45,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it('User should follow, and fail to re-initialize the follow NFT', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -57,7 +57,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it("User should follow, userTwo should fail to burn user's follow NFT", async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           userTwo
         );
 
@@ -67,7 +67,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it('User should follow, then fail to mint a follow NFT directly', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -77,7 +77,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it('User should follow, then fail to get the power at a future block', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -94,7 +94,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it('user should follow, then fail to get the URI for a token that does not exist', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
         await expect(followNFT.tokenURI(2)).to.be.revertedWith(ERRORS.TOKEN_DOES_NOT_EXIST);
@@ -105,7 +105,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it('User should follow, then burn their follow NFT, governance power is zero before and after', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
         const firstCheckpointBlock = await getBlockNumber();
@@ -123,7 +123,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it('User should follow, delegate to themself, governance power should be zero before the last block, and 1 at the current block', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -141,7 +141,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -236,7 +236,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -281,7 +281,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -298,7 +298,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
 
@@ -338,7 +338,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
       it('user should follow, then get the URI for their token, URI should be accurate', async function () {
         await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
         const followNFT = FollowNFT__factory.connect(
-          await lensHub.getFollowNFT(FIRST_PROFILE_ID),
+          (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT,
           user
         );
         expect(await followNFT.tokenURI(1)).to.eq(MOCK_FOLLOW_NFT_URI);
@@ -350,7 +350,7 @@ makeSuiteCleanRoom('Follow NFT', function () {
     let followNFT: FollowNFT;
     beforeEach(async function () {
       await expect(lensHub.connect(testWallet).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
-      followNFT = FollowNFT__factory.connect(await lensHub.getFollowNFT(FIRST_PROFILE_ID), user);
+      followNFT = FollowNFT__factory.connect((await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT, user);
     });
 
     context('negatives', function () {

--- a/test/other/deployment-validation.spec.ts
+++ b/test/other/deployment-validation.spec.ts
@@ -25,19 +25,20 @@ import {
   TREASURY_FEE_BPS,
   user,
   userAddress,
+  whitelist,
 } from '../__setup.spec';
 
 makeSuiteCleanRoom('deployment validation', () => {
   it('Deployer should not be able to initialize implementation due to address(this) check', async function () {
     await expect(
-      lensHubImpl.initialize(LENS_HUB_NFT_NAME, LENS_HUB_NFT_SYMBOL, governanceAddress)
+      lensHubImpl.initialize(LENS_HUB_NFT_NAME, LENS_HUB_NFT_SYMBOL, governanceAddress, whitelist.address)
     ).to.be.revertedWith(ERRORS.CANNOT_INIT_IMPL);
   });
 
   it("User should fail to initialize lensHub proxy after it's already been initialized via the proxy constructor", async function () {
     // Initialization happens in __setup.spec.ts
     await expect(
-      lensHub.connect(user).initialize('name', 'symbol', userAddress)
+      lensHub.connect(user).initialize('name', 'symbol', userAddress, whitelist.address)
     ).to.be.revertedWith(ERRORS.INITIALIZED);
   });
 
@@ -51,6 +52,7 @@ makeSuiteCleanRoom('deployment validation', () => {
       LENS_HUB_NFT_NAME,
       LENS_HUB_NFT_SYMBOL,
       governanceAddress,
+      whitelist.address,
     ]);
 
     const proxy = await new TransparentUpgradeableProxy__factory(deployer).deploy(
@@ -60,7 +62,7 @@ makeSuiteCleanRoom('deployment validation', () => {
     );
 
     await expect(
-      LensHub__factory.connect(proxy.address, user).initialize('name', 'symbol', userAddress)
+      LensHub__factory.connect(proxy.address, user).initialize('name', 'symbol', userAddress, whitelist.address)
     ).to.be.revertedWith(ERRORS.INITIALIZED);
   });
 

--- a/test/other/events.spec.ts
+++ b/test/other/events.spec.ts
@@ -446,7 +446,7 @@ makeSuiteCleanRoom('Events', function () {
       );
 
       receipt = await waitForTx(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]]));
-      const followNFT = await lensHub.getFollowNFT(FIRST_PROFILE_ID);
+      const followNFT = (await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT;
 
       const expectedName = MOCK_PROFILE_HANDLE + '-Follower';
       const expectedSymbol = getAbbreviation(MOCK_PROFILE_HANDLE) + '-Fl';

--- a/test/other/events.spec.ts
+++ b/test/other/events.spec.ts
@@ -34,6 +34,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../__setup.spec';
 
 /**
@@ -53,6 +54,7 @@ makeSuiteCleanRoom('Events', function () {
         LENS_HUB_NFT_NAME,
         LENS_HUB_NFT_SYMBOL,
         governanceAddress,
+        whitelist.address,
       ]);
 
       let proxy = await new TransparentUpgradeableProxy__factory(deployer).deploy(
@@ -178,13 +180,13 @@ makeSuiteCleanRoom('Events', function () {
 
     it('Follow module whitelisting functions should emit expected event', async function () {
       receipt = await waitForTx(
-        lensHub.connect(governance).whitelistFollowModule(userAddress, true)
+        whitelist.connect(governance).whitelistFollowModule(userAddress, true)
       );
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'FollowModuleWhitelisted', [userAddress, true, await getTimestamp()]);
 
       receipt = await waitForTx(
-        lensHub.connect(governance).whitelistFollowModule(userAddress, false)
+        whitelist.connect(governance).whitelistFollowModule(userAddress, false)
       );
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'FollowModuleWhitelisted', [userAddress, false, await getTimestamp()]);
@@ -192,13 +194,13 @@ makeSuiteCleanRoom('Events', function () {
 
     it('Reference module whitelisting functions should emit expected event', async function () {
       receipt = await waitForTx(
-        lensHub.connect(governance).whitelistReferenceModule(userAddress, true)
+        whitelist.connect(governance).whitelistReferenceModule(userAddress, true)
       );
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'ReferenceModuleWhitelisted', [userAddress, true, await getTimestamp()]);
 
       receipt = await waitForTx(
-        lensHub.connect(governance).whitelistReferenceModule(userAddress, false)
+        whitelist.connect(governance).whitelistReferenceModule(userAddress, false)
       );
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'ReferenceModuleWhitelisted', [userAddress, false, await getTimestamp()]);
@@ -206,13 +208,13 @@ makeSuiteCleanRoom('Events', function () {
 
     it('Collect module whitelisting functions should emit expected event', async function () {
       receipt = await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(userAddress, true)
+        whitelist.connect(governance).whitelistCollectModule(userAddress, true)
       );
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'CollectModuleWhitelisted', [userAddress, true, await getTimestamp()]);
 
       receipt = await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(userAddress, false)
+        whitelist.connect(governance).whitelistCollectModule(userAddress, false)
       );
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'CollectModuleWhitelisted', [userAddress, false, await getTimestamp()]);
@@ -296,7 +298,7 @@ makeSuiteCleanRoom('Events', function () {
       await createProfile();
 
       await waitForTx(
-        lensHub.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
+        whitelist.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
       );
 
       receipt = await waitForTx(
@@ -325,7 +327,7 @@ makeSuiteCleanRoom('Events', function () {
       await createProfile();
 
       await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       );
 
       receipt = await waitForTx(
@@ -356,7 +358,7 @@ makeSuiteCleanRoom('Events', function () {
       await createProfile();
 
       await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       );
       await waitForTx(
         lensHub.post({
@@ -402,7 +404,7 @@ makeSuiteCleanRoom('Events', function () {
       await createProfile();
 
       await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       );
       await waitForTx(
         lensHub.post({
@@ -442,7 +444,7 @@ makeSuiteCleanRoom('Events', function () {
       await createProfile();
 
       await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       );
 
       receipt = await waitForTx(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]]));
@@ -468,7 +470,7 @@ makeSuiteCleanRoom('Events', function () {
       await createProfile();
 
       await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       );
 
       await waitForTx(
@@ -522,7 +524,7 @@ makeSuiteCleanRoom('Events', function () {
       await createProfile();
 
       await waitForTx(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       );
 
       await waitForTx(

--- a/test/other/misc.spec.ts
+++ b/test/other/misc.spec.ts
@@ -83,7 +83,7 @@ makeSuiteCleanRoom('Misc', function () {
     });
 
     it('Profile handle getter should return the correct handle', async function () {
-      expect(await lensHub.getHandle(FIRST_PROFILE_ID)).to.eq(MOCK_PROFILE_HANDLE);
+      expect((await lensHub.getProfile(FIRST_PROFILE_ID)).handle).to.eq(MOCK_PROFILE_HANDLE);
     });
 
     it('Profile dispatcher getter should return the zero address when no dispatcher is set', async function () {
@@ -109,15 +109,15 @@ makeSuiteCleanRoom('Misc', function () {
     });
 
     it('Profile follow NFT getter should return the zero address before the first follow, then the correct address afterwards', async function () {
-      expect(await lensHub.getFollowNFT(FIRST_PROFILE_ID)).to.eq(ZERO_ADDRESS);
+      expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT).to.eq(ZERO_ADDRESS);
 
       await expect(lensHub.follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
 
-      expect(await lensHub.getFollowNFT(FIRST_PROFILE_ID)).to.not.eq(ZERO_ADDRESS);
+      expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followNFT).to.not.eq(ZERO_ADDRESS);
     });
 
     it('Profile follow module getter should return the zero address, then the correct follow module after it is set', async function () {
-      expect(await lensHub.getFollowModule(FIRST_PROFILE_ID)).to.eq(ZERO_ADDRESS);
+      expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followModule).to.eq(ZERO_ADDRESS);
 
       await expect(
         lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
@@ -126,11 +126,13 @@ makeSuiteCleanRoom('Misc', function () {
       await expect(
         lensHub.setFollowModule(FIRST_PROFILE_ID, mockFollowModule.address, mockModuleData)
       ).to.not.be.reverted;
-      expect(await lensHub.getFollowModule(FIRST_PROFILE_ID)).to.eq(mockFollowModule.address);
+      expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followModule).to.eq(
+        mockFollowModule.address
+      );
     });
 
     it('Profile publication count getter should return zero, then the correct amount after some publications', async function () {
-      expect(await lensHub.getPubCount(FIRST_PROFILE_ID)).to.eq(0);
+      expect((await lensHub.getProfile(FIRST_PROFILE_ID)).pubCount).to.eq(0);
 
       await expect(
         lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
@@ -149,7 +151,7 @@ makeSuiteCleanRoom('Misc', function () {
           })
         ).to.not.be.reverted;
       }
-      expect(await lensHub.getPubCount(FIRST_PROFILE_ID)).to.eq(expectedCount);
+      expect((await lensHub.getProfile(FIRST_PROFILE_ID)).pubCount).to.eq(expectedCount);
     });
 
     it('Profile tokenURI should return the accurate URI', async function () {

--- a/test/other/misc.spec.ts
+++ b/test/other/misc.spec.ts
@@ -28,6 +28,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../__setup.spec';
 
 /**
@@ -91,11 +92,11 @@ makeSuiteCleanRoom('Misc', function () {
     });
 
     it('Profile creator whitelist getter should return expected values', async function () {
-      expect(await lensHub.isProfileCreatorWhitelisted(userAddress)).to.eq(true);
+      expect(await whitelist.isProfileCreatorWhitelisted(userAddress)).to.eq(true);
       await expect(
-        lensHub.connect(governance).whitelistProfileCreator(userAddress, false)
+        whitelist.connect(governance).whitelistProfileCreator(userAddress, false)
       ).to.not.be.reverted;
-      expect(await lensHub.isProfileCreatorWhitelisted(userAddress)).to.eq(false);
+      expect(await whitelist.isProfileCreatorWhitelisted(userAddress)).to.eq(false);
     });
 
     it('Profile dispatcher getter should return the correct dispatcher address when it is set, then zero after it is transferred', async function () {
@@ -120,7 +121,7 @@ makeSuiteCleanRoom('Misc', function () {
       expect((await lensHub.getProfile(FIRST_PROFILE_ID)).followModule).to.eq(ZERO_ADDRESS);
 
       await expect(
-        lensHub.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
+        whitelist.connect(governance).whitelistFollowModule(mockFollowModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -135,7 +136,7 @@ makeSuiteCleanRoom('Misc', function () {
       expect((await lensHub.getProfile(FIRST_PROFILE_ID)).pubCount).to.eq(0);
 
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       const expectedCount = 5;
@@ -160,11 +161,11 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication reference module getter should return the correct reference module (or zero in case of no reference module)', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
-        lensHub
+        whitelist
           .connect(governance)
           .whitelistReferenceModule(followerOnlyReferenceModule.address, true)
       ).to.not.be.reverted;
@@ -198,7 +199,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication pointer getter should return an empty pointer for posts', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -219,7 +220,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication pointer getter should return the correct pointer for comments', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -253,7 +254,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication pointer getter should return the correct pointer for mirrors', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -284,7 +285,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication content URI getter should return the correct URI for posts', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -303,7 +304,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication content URI getter should return the correct URI for comments', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -335,7 +336,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication content URI getter should return the correct URI for mirrors', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -363,7 +364,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication collect module getter should return the correct collectModule for posts', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -382,7 +383,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication collect module getter should return the correct collectModule for comments', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -424,7 +425,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication collect module getter should return the zero address for mirrors', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -453,7 +454,7 @@ makeSuiteCleanRoom('Misc', function () {
 
     it('Publication type getter should return the correct publication type for all publication types, or nonexistent', async function () {
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -508,7 +509,7 @@ makeSuiteCleanRoom('Misc', function () {
   context('Follow Module Misc', function () {
     beforeEach(async function () {
       await expect(
-        lensHub.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
+        whitelist.connect(governance).whitelistFollowModule(approvalFollowModule.address, true)
       ).to.not.be.reverted;
 
       await expect(
@@ -660,7 +661,7 @@ makeSuiteCleanRoom('Misc', function () {
 
       // Then, whitelist a collect module
       await expect(
-        lensHub.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
+        whitelist.connect(governance).whitelistCollectModule(emptyCollectModule.address, true)
       ).to.not.be.reverted;
 
       // Then, publish twice

--- a/test/other/mock-profile-creation-proxy.spec.ts
+++ b/test/other/mock-profile-creation-proxy.spec.ts
@@ -28,6 +28,7 @@ import {
   userAddress,
   userTwo,
   userTwoAddress,
+  whitelist,
 } from '../__setup.spec';
 import { BigNumber } from 'ethers';
 import { TokenDataStructOutput } from '../../typechain-types/LensHub';
@@ -40,7 +41,7 @@ makeSuiteCleanRoom('Mock Profile Creation Proxy', function () {
       lensHub.address
     );
     await expect(
-      lensHub.connect(governance).whitelistProfileCreator(mockProfileCreationProxy.address, true)
+      whitelist.connect(governance).whitelistProfileCreator(mockProfileCreationProxy.address, true)
     ).to.not.be.reverted;
   });
 


### PR DESCRIPTION
- View functions add a lot of convenience, but as we are very close to the size limit removing some of view functions to decrease contract size. `24.451Kb -> 24.174Kb`
- whitelisting moved to a seperate contract, this reduces the size to `23.759 Kb`
  - the whitelisting contracts add additional gas overhead of min. 10k per call  [gas_comparison.txt](https://github.com/aave/lens-protocol/files/8251490/gas_comparison.txt)
 