### PR TITLE
Misc: Update Expected Test Revert Reasons

### DIFF
--- a/test/hub/interactions/multi-state-hub.spec.ts
+++ b/test/hub/interactions/multi-state-hub.spec.ts
@@ -471,7 +471,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
             referenceModule: ZERO_ADDRESS,
             referenceModuleData: [],
           })
-        ).to.be.revertedWith(ERRORS.PAUSED);
+        ).to.be.revertedWith(ERRORS.PUBLISHING_PAUSED);
 
         await expect(
           lensHub.connect(governance).setState(ProtocolState.Unpaused)
@@ -537,7 +537,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
               deadline: MAX_UINT256,
             },
           })
-        ).to.be.revertedWith(ERRORS.PAUSED);
+        ).to.be.revertedWith(ERRORS.PUBLISHING_PAUSED);
 
         await expect(
           lensHub.connect(governance).setState(ProtocolState.Unpaused)
@@ -601,7 +601,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
             referenceModule: ZERO_ADDRESS,
             referenceModuleData: [],
           })
-        ).to.be.revertedWith(ERRORS.PAUSED);
+        ).to.be.revertedWith(ERRORS.PUBLISHING_PAUSED);
 
         await expect(
           lensHub.connect(governance).setState(ProtocolState.Unpaused)
@@ -684,7 +684,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
               deadline: MAX_UINT256,
             },
           })
-        ).to.be.revertedWith(ERRORS.PAUSED);
+        ).to.be.revertedWith(ERRORS.PUBLISHING_PAUSED);
 
         await expect(
           lensHub.connect(governance).setState(ProtocolState.Unpaused)
@@ -747,7 +747,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
             referenceModule: ZERO_ADDRESS,
             referenceModuleData: [],
           })
-        ).to.be.revertedWith(ERRORS.PAUSED);
+        ).to.be.revertedWith(ERRORS.PUBLISHING_PAUSED);
 
         await expect(
           lensHub.connect(governance).setState(ProtocolState.Unpaused)
@@ -820,7 +820,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
               deadline: MAX_UINT256,
             },
           })
-        ).to.be.revertedWith(ERRORS.PAUSED);
+        ).to.be.revertedWith(ERRORS.PUBLISHING_PAUSED);
 
         await expect(
           lensHub.connect(governance).setState(ProtocolState.Unpaused)


### PR DESCRIPTION
This PR adds validation to ensure that attempting to publish when the state is `Paused` or `PublishingPaused` now reverts with the expected `PublishingPaused()` error.

**Note** that this reveals a flaw in previous testing in that a check expecting a transaction to be `revertedWith("error")` would pass as long as the revert string or error name contains the string `error`, which could lead to reverts for incorrect reasons remaining hidden. 