### PR TITLE
Fix permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3.5'
 
 services:
   contracts-env:
-    security_opt:
-      - no-new-privileges
     user: "${USERID?}:${USERID?}"
     env_file:
       - .env


### PR DESCRIPTION
`security_opt` breaks the setup for some people (see #71)

The security benefit for local environments is negligible, so I've just removed it