### PR TITLE
fix: Remove the BPS_MAX Minimum Fee Requirement

### DIFF
--- a/contracts/core/modules/collect/FeeCollectModule.sol
+++ b/contracts/core/modules/collect/FeeCollectModule.sol
@@ -69,7 +69,7 @@ contract FeeCollectModule is ICollectModule, FeeModuleBase, FollowValidationModu
             !_currencyWhitelisted(currency) ||
             recipient == address(0) ||
             referralFee > BPS_MAX ||
-            amount < BPS_MAX
+            amount == 0
         ) revert Errors.InitParamsInvalid();
 
         _dataByPublicationByProfile[profileId][pubId].referralFee = referralFee;

--- a/contracts/core/modules/collect/LimitedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/LimitedFeeCollectModule.sol
@@ -76,7 +76,7 @@ contract LimitedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidat
             !_currencyWhitelisted(currency) ||
             recipient == address(0) ||
             referralFee > BPS_MAX ||
-            amount < BPS_MAX
+            amount == 0
         ) revert Errors.InitParamsInvalid();
 
         _dataByPublicationByProfile[profileId][pubId].collectLimit = collectLimit;

--- a/contracts/core/modules/collect/LimitedTimedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/LimitedTimedFeeCollectModule.sol
@@ -83,7 +83,7 @@ contract LimitedTimedFeeCollectModule is ICollectModule, FeeModuleBase, FollowVa
             !_currencyWhitelisted(currency) ||
             recipient == address(0) ||
             referralFee > BPS_MAX ||
-            amount < BPS_MAX
+            amount == 0
         ) revert Errors.InitParamsInvalid();
 
         _dataByPublicationByProfile[profileId][pubId].collectLimit = collectLimit;

--- a/contracts/core/modules/collect/TimedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/TimedFeeCollectModule.sol
@@ -78,7 +78,7 @@ contract TimedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidatio
             !_currencyWhitelisted(currency) ||
             recipient == address(0) ||
             referralFee > BPS_MAX ||
-            amount < BPS_MAX
+            amount == 0
         ) revert Errors.InitParamsInvalid();
 
         _dataByPublicationByProfile[profileId][pubId].amount = amount;

--- a/contracts/core/modules/follow/FeeFollowModule.sol
+++ b/contracts/core/modules/follow/FeeFollowModule.sol
@@ -59,7 +59,7 @@ contract FeeFollowModule is IFollowModule, FeeModuleBase, FollowValidatorFollowM
             data,
             (uint256, address, address)
         );
-        if (!_currencyWhitelisted(currency) || recipient == address(0) || amount < BPS_MAX)
+        if (!_currencyWhitelisted(currency) || recipient == address(0) || amount == 0)
             revert Errors.InitParamsInvalid();
 
         _dataByProfile[profileId].amount = amount;

--- a/test/modules/collect/fee-collect-module.spec.ts
+++ b/test/modules/collect/fee-collect-module.spec.ts
@@ -102,10 +102,10 @@ makeSuiteCleanRoom('Fee Collect Module', function () {
         ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
       });
 
-      it('user should fail to post with fee collect module using amount lower than max BPS', async function () {
+      it('user should fail to post with fee collect module using zero amount', async function () {
         const collectModuleData = abiCoder.encode(
           ['uint256', 'address', 'address', 'uint16'],
-          [9999, currency.address, userAddress, REFERRAL_FEE_BPS]
+          [0, currency.address, userAddress, REFERRAL_FEE_BPS]
         );
         await expect(
           lensHub.post({

--- a/test/modules/collect/limited-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-fee-collect-module.spec.ts
@@ -132,10 +132,10 @@ makeSuiteCleanRoom('Limited Fee Collect Module', function () {
         ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
       });
 
-      it('user should fail to post with limited fee collect module using amount lower than max BPS', async function () {
+      it('user should fail to post with limited fee collect module using zero amount', async function () {
         const collectModuleData = abiCoder.encode(
           ['uint256', 'uint256', 'address', 'address', 'uint16'],
-          [DEFAULT_COLLECT_LIMIT, 9999, currency.address, userAddress, REFERRAL_FEE_BPS]
+          [DEFAULT_COLLECT_LIMIT, 0, currency.address, userAddress, REFERRAL_FEE_BPS]
         );
         await expect(
           lensHub.post({

--- a/test/modules/collect/limited-timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-timed-fee-collect-module.spec.ts
@@ -132,10 +132,10 @@ makeSuiteCleanRoom('Limited Timed Fee Collect Module', function () {
         ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
       });
 
-      it('user should fail to post with limited timed fee collect module using amount lower than max BPS', async function () {
+      it('user should fail to post with limited timed fee collect module using zero amount', async function () {
         const collectModuleData = abiCoder.encode(
           ['uint256', 'uint256', 'address', 'address', 'uint16'],
-          [DEFAULT_COLLECT_LIMIT, 9999, currency.address, userAddress, REFERRAL_FEE_BPS]
+          [DEFAULT_COLLECT_LIMIT, 0, currency.address, userAddress, REFERRAL_FEE_BPS]
         );
         await expect(
           lensHub.post({

--- a/test/modules/collect/timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/timed-fee-collect-module.spec.ts
@@ -102,10 +102,10 @@ makeSuiteCleanRoom('Timed Fee Collect Module', function () {
         ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
       });
 
-      it('user should fail to post with timed fee collect module using amount lower than max BPS', async function () {
+      it('user should fail to post with timed fee collect module using zero amount', async function () {
         const collectModuleData = abiCoder.encode(
           ['uint256', 'address', 'address', 'uint16'],
-          [9999, currency.address, userAddress, REFERRAL_FEE_BPS]
+          [0, currency.address, userAddress, REFERRAL_FEE_BPS]
         );
         await expect(
           lensHub.post({

--- a/test/modules/follow/fee-follow-module.spec.ts
+++ b/test/modules/follow/fee-follow-module.spec.ts
@@ -76,10 +76,10 @@ makeSuiteCleanRoom('Fee Follow Module', function () {
         ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
       });
 
-      it('user should fail to create a profile with fee follow module using amount lower than max BPS', async function () {
+      it('user should fail to create a profile with fee follow module using zero amount', async function () {
         const followModuleData = abiCoder.encode(
           ['uint256', 'address', 'address'],
-          [9999, currency.address, userAddress]
+          [0, currency.address, userAddress]
         );
 
         await expect(


### PR DESCRIPTION
This PR removes the requirement from fee modules to have fees of at least 10,000, instead ensuring that they are non-zero. Clearly this adds rounding to the mix and is a bit of a pain, but the contracts account for it by subtracting the treasury and referral fees instead of directly pre-calculating fee amounts.