### PR TITLE
fix: Prevent Follow & Collect NFT Implementation Initialization

### DIFF
--- a/contracts/core/CollectNFT.sol
+++ b/contracts/core/CollectNFT.sol
@@ -28,6 +28,7 @@ contract CollectNFT is ICollectNFT, LensNFTBase {
     // to initialize the hub proxy at construction.
     constructor(address hub) {
         HUB = hub;
+        _initialized = true;
     }
 
     /// @inheritdoc ICollectNFT

--- a/contracts/core/FollowNFT.sol
+++ b/contracts/core/FollowNFT.sol
@@ -46,6 +46,7 @@ contract FollowNFT is LensNFTBase, IFollowNFT {
     // We create the FollowNFT with the pre-computed HUB address before deploying the hub.
     constructor(address hub) {
         HUB = hub;
+        _initialized = true;
     }
 
     /// @inheritdoc IFollowNFT


### PR DESCRIPTION
This PR prevents initialization of the Follow & Collect NFT implementations, which should have no effect on protocol functionality, but no longer allows anyone to, for instance, set the implementation's NFT name.