### PR TITLE
fix: Prevent Treasury Transfers if the Treasury Fee Is Zero

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -2,6 +2,8 @@ module.exports = {
   skipFiles: [
     '/core/base/ERC721Time.sol',
     '/core/base/ERC721Enumerable.sol',
+    '/core/modules/follow/SecretCodeFollowModule.sol',
+    '/upgradeability',
     '/interfaces',
     '/mocks',
   ],

--- a/contracts/core/modules/collect/FeeCollectModule.sol
+++ b/contracts/core/modules/collect/FeeCollectModule.sol
@@ -133,7 +133,8 @@ contract FeeCollectModule is ICollectModule, FeeModuleBase, FollowValidationModu
         uint256 adjustedAmount = amount - treasuryAmount;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 
     function _processCollectWithReferral(
@@ -173,6 +174,7 @@ contract FeeCollectModule is ICollectModule, FeeModuleBase, FollowValidationModu
         address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 }

--- a/contracts/core/modules/collect/LimitedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/LimitedFeeCollectModule.sol
@@ -151,7 +151,8 @@ contract LimitedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidat
         uint256 adjustedAmount = amount - treasuryAmount;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 
     function _processCollectWithReferral(
@@ -191,6 +192,7 @@ contract LimitedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidat
         address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 }

--- a/contracts/core/modules/collect/LimitedTimedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/LimitedTimedFeeCollectModule.sol
@@ -162,7 +162,8 @@ contract LimitedTimedFeeCollectModule is ICollectModule, FeeModuleBase, FollowVa
         uint256 adjustedAmount = amount - treasuryAmount;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 
     function _processCollectWithReferral(
@@ -202,6 +203,7 @@ contract LimitedTimedFeeCollectModule is ICollectModule, FeeModuleBase, FollowVa
         address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 }

--- a/contracts/core/modules/collect/TimedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/TimedFeeCollectModule.sol
@@ -147,7 +147,8 @@ contract TimedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidatio
         uint256 adjustedAmount = amount - treasuryAmount;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 
     function _processCollectWithReferral(
@@ -187,6 +188,7 @@ contract TimedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidatio
         address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
 
         IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
     }
 }

--- a/contracts/core/modules/follow/FeeFollowModule.sol
+++ b/contracts/core/modules/follow/FeeFollowModule.sol
@@ -87,7 +87,8 @@ contract FeeFollowModule is IFollowModule, FeeModuleBase, FollowValidatorFollowM
         uint256 adjustedAmount = amount - treasuryAmount;
 
         IERC20(currency).safeTransferFrom(follower, recipient, adjustedAmount);
-        IERC20(currency).safeTransferFrom(follower, treasury, treasuryAmount);
+        if (treasuryAmount > 0)
+            IERC20(currency).safeTransferFrom(follower, treasury, treasuryAmount);
     }
 
     /**

--- a/test/modules/collect/fee-collect-module.spec.ts
+++ b/test/modules/collect/fee-collect-module.spec.ts
@@ -164,11 +164,77 @@ makeSuiteCleanRoom('Fee Collect Module', function () {
           }
         }
         expect(currencyEventCount).to.eq(1);
-        const amount = abiCoder.encode(['uint256'], [DEFAULT_COLLECT_PRICE]);
         matchEvent(
           receipt,
           'Transfer',
           [userTwoAddress, userAddress, DEFAULT_COLLECT_PRICE],
+          currency,
+          currency.address
+        );
+      });
+
+      it('UserTwo should mirror the original post, governance should set the treasury fee BPS to zero, userTwo collecting their mirror should not emit a transfer event to the treasury', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(feeCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+
+        const tx = lensHub.connect(userTwo).collect(secondProfileId, 1, data);
+        const receipt = await waitForTx(tx);
+
+        let currencyEventCount = 0;
+        for (let log of receipt.logs) {
+          if (log.address == currency.address) {
+            currencyEventCount++;
+          }
+        }
+        expect(currencyEventCount).to.eq(2);
+
+        const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .mul(REFERRAL_FEE_BPS)
+          .div(BPS_MAX);
+        const amount = DEFAULT_COLLECT_PRICE.sub(expectedReferralAmount);
+
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userAddress, amount],
+          currency,
+          currency.address
+        );
+
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userTwoAddress, expectedReferralAmount],
           currency,
           currency.address
         );

--- a/test/modules/collect/limited-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-fee-collect-module.spec.ts
@@ -174,6 +174,38 @@ makeSuiteCleanRoom('Limited Fee Collect Module', function () {
         ).to.not.be.reverted;
       });
 
+      it('Governance should set the treasury fee BPS to zero, userTwo collecting should not emit a transfer event to the treasury', async function () {
+        await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(limitedFeeCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+
+        const tx = lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data);
+        const receipt = await waitForTx(tx);
+
+        let currencyEventCount = 0;
+        for (let log of receipt.logs) {
+          if (log.address == currency.address) {
+            currencyEventCount++;
+          }
+        }
+        expect(currencyEventCount).to.eq(1);
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userAddress, DEFAULT_COLLECT_PRICE],
+          currency,
+          currency.address
+        );
+      });
+
       it('UserTwo should fail to collect without following', async function () {
         const data = abiCoder.encode(
           ['address', 'uint256'],

--- a/test/modules/collect/limited-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-fee-collect-module.spec.ts
@@ -206,6 +206,73 @@ makeSuiteCleanRoom('Limited Fee Collect Module', function () {
         );
       });
 
+      it('UserTwo should mirror the original post, governance should set the treasury fee BPS to zero, userTwo collecting their mirror should not emit a transfer event to the treasury', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(limitedFeeCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+
+        const tx = lensHub.connect(userTwo).collect(secondProfileId, 1, data);
+        const receipt = await waitForTx(tx);
+
+        let currencyEventCount = 0;
+        for (let log of receipt.logs) {
+          if (log.address == currency.address) {
+            currencyEventCount++;
+          }
+        }
+        expect(currencyEventCount).to.eq(2);
+
+        const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .mul(REFERRAL_FEE_BPS)
+          .div(BPS_MAX);
+        const amount = DEFAULT_COLLECT_PRICE.sub(expectedReferralAmount);
+
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userAddress, amount],
+          currency,
+          currency.address
+        );
+
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userTwoAddress, expectedReferralAmount],
+          currency,
+          currency.address
+        );
+      });
+
       it('UserTwo should fail to collect without following', async function () {
         const data = abiCoder.encode(
           ['address', 'uint256'],

--- a/test/modules/collect/limited-timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-timed-fee-collect-module.spec.ts
@@ -174,6 +174,38 @@ makeSuiteCleanRoom('Limited Timed Fee Collect Module', function () {
         ).to.not.be.reverted;
       });
 
+      it('Governance should set the treasury fee BPS to zero, userTwo collecting should not emit a transfer event to the treasury', async function () {
+        await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(limitedTimedFeeCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+
+        const tx = lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data);
+        const receipt = await waitForTx(tx);
+
+        let currencyEventCount = 0;
+        for (let log of receipt.logs) {
+          if (log.address == currency.address) {
+            currencyEventCount++;
+          }
+        }
+        expect(currencyEventCount).to.eq(1);
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userAddress, DEFAULT_COLLECT_PRICE],
+          currency,
+          currency.address
+        );
+      });
+
       it('UserTwo should fail to collect without following', async function () {
         const data = abiCoder.encode(
           ['address', 'uint256'],

--- a/test/modules/collect/timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/timed-fee-collect-module.spec.ts
@@ -170,6 +170,73 @@ makeSuiteCleanRoom('Timed Fee Collect Module', function () {
         );
       });
 
+      it('UserTwo should mirror the original post, governance should set the treasury fee BPS to zero, userTwo collecting their mirror should not emit a transfer event to the treasury', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+        await expect(
+          currency.connect(userTwo).approve(timedFeeCollectModule.address, MAX_UINT256)
+        ).to.not.be.reverted;
+
+        const tx = lensHub.connect(userTwo).collect(secondProfileId, 1, data);
+        const receipt = await waitForTx(tx);
+
+        let currencyEventCount = 0;
+        for (let log of receipt.logs) {
+          if (log.address == currency.address) {
+            currencyEventCount++;
+          }
+        }
+        expect(currencyEventCount).to.eq(2);
+
+        const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+          .mul(REFERRAL_FEE_BPS)
+          .div(BPS_MAX);
+        const amount = DEFAULT_COLLECT_PRICE.sub(expectedReferralAmount);
+
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userAddress, amount],
+          currency,
+          currency.address
+        );
+
+        matchEvent(
+          receipt,
+          'Transfer',
+          [userTwoAddress, userTwoAddress, expectedReferralAmount],
+          currency,
+          currency.address
+        );
+      });
+
       it('UserTwo should fail to collect without following', async function () {
         const data = abiCoder.encode(
           ['address', 'uint256'],


### PR DESCRIPTION
This PR prevents transfers to the treasury if the computed treasury fee amount is zero. Note that this still includes the treasury fee computation as, in cases with very few decimals, it's possible the treasury fee amount is zero even if the treasury fee BPS is non-zero.