### PR TITLE
feat: Add Profile Metadata System

### DIFF
--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -342,6 +342,21 @@ library DataTypes {
         EIP712Signature sig;
     }
 
+    /** 
+     * @notice A struct containing the parameters required for the `setProfileMetadataWithSig()` function.
+     *
+     * @param user The user which is the message signer.
+     * @param profileId The profile ID for which to set the metadata.
+     * @param metadata The metadata string to set for the profile and user.
+     * @param sig The EIP712Signature struct containing the user's signature.
+     */
+    struct SetProfileMetadataWithSigData {
+        address user;
+        uint256 profileId;
+        string metadata;
+        EIP712Signature sig;
+    }
+
     /**
      * @notice A struct containing the parameters required for the `toggleFollowWithSig()` function.
      *

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -20,6 +20,7 @@ library Errors {
     error ProfileCreatorNotWhitelisted();
     error NotProfileOwner();
     error NotProfileOwnerOrDispatcher();
+    error NotDispatcher();
     error PublicationDoesNotExist();
     error HandleTaken();
     error HandleLengthInvalid();

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -476,7 +476,7 @@ library Events {
     );
 
     /**
-     * @dev Emitted when the user wants to enable or disable the follow.
+     * @dev Emitted when the user wants to enable or disable follows in the `LensPeripheryDataProvider`.
      *
      * @param owner The profile owner who executed the toggle.
      * @param profileIds The array of token IDs of the profiles each followNFT is associated with.
@@ -490,4 +490,18 @@ library Events {
         uint256 timestamp
     );
 
+    /**
+     * @dev Emitted when the metadata associated with a profile and user is set in the `LensPeripheryDataProvider`.
+     *
+     * @param user The user the metadata is set for.
+     * @param profileId The profile ID the metadata is set for.
+     * @param metadata The metadata set for the profile and user.
+     * @param timestamp The current block timestamp.
+     */
+    event ProfileMetadataSet(
+        address indexed user,
+        uint256 indexed profileId,
+        string metadata,
+        uint256 timestamp
+    );
 }


### PR DESCRIPTION
This PR adds a profile metadata system to the `LensPeripheryDataProvider` contract, allowing users to set the profile metadata for any profile. The logic behind this is that if I transfer a profile to someone, their metadata should be different, but if I get it back, it should be the same. 