### PR TITLE
refacto: minor for-loops gas optimizations

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -535,8 +535,12 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
         whenNotPaused
     {
         bytes32[] memory dataHashes = new bytes32[](vars.datas.length);
-        for (uint256 i = 0; i < vars.datas.length; ++i) {
+        uint256 dataLength = vars.datas.length;
+        for (uint256 i; i < dataLength; ) {
             dataHashes[i] = keccak256(vars.datas[i]);
+            unchecked {
+                i++;
+            }
         }
         _validateRecoveredAddress(
             _calculateDigest(

--- a/contracts/core/modules/follow/ApprovalFollowModule.sol
+++ b/contracts/core/modules/follow/ApprovalFollowModule.sol
@@ -34,12 +34,16 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
         address[] calldata addresses,
         bool[] calldata toApprove
     ) external {
-        if (addresses.length != toApprove.length) revert Errors.InitParamsInvalid();
+        uint256 addressesLength = addresses.length;
+        if (addressesLength != toApprove.length) revert Errors.InitParamsInvalid();
         address owner = IERC721(HUB).ownerOf(profileId);
         if (msg.sender != owner) revert Errors.NotProfileOwner();
 
-        for (uint256 i = 0; i < addresses.length; ++i) {
+        for (uint256 i; i < addressesLength; ) {
             _approvedByProfileByOwner[owner][profileId][addresses[i]] = toApprove[i];
+            unchecked {
+                i++;
+            }
         }
 
         emit Events.FollowsApproved(owner, profileId, addresses, toApprove, block.timestamp);
@@ -63,8 +67,12 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
 
         if (data.length > 0) {
             address[] memory addresses = abi.decode(data, (address[]));
-            for (uint256 i = 0; i < addresses.length; ++i) {
+            uint256 addressesLength = addresses.length;
+            for (uint256 i; i < addressesLength; ) {
                 _approvedByProfileByOwner[owner][profileId][addresses[i]] = true;
+                unchecked {
+                    i++;
+                }
             }
         }
         return data;
@@ -125,8 +133,12 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
         address[] calldata toCheck
     ) external view returns (bool[] memory) {
         bool[] memory approved = new bool[](toCheck.length);
-        for (uint256 i = 0; i < toCheck.length; ++i) {
+        uint256 toCheckLength = toCheck.length;
+        for (uint256 i; i < toCheckLength; ) {
             approved[i] = _approvedByProfileByOwner[profileOwner][profileId][toCheck[i]];
+            unchecked {
+                i++;
+            }
         }
         return approved;
     }

--- a/contracts/libraries/InteractionLogic.sol
+++ b/contracts/libraries/InteractionLogic.sol
@@ -45,7 +45,7 @@ library InteractionLogic {
         mapping(bytes32 => uint256) storage _profileIdByHandleHash
     ) external {
         if (profileIds.length != followModuleDatas.length) revert Errors.ArrayMismatch();
-        for (uint256 i = 0; i < profileIds.length; ++i) {
+        for (uint256 i; i < profileIds.length; ) {
             string memory handle = _profileById[profileIds[i]].handle;
             if (_profileIdByHandleHash[keccak256(bytes(handle))] != profileIds[i])
                 revert Errors.TokenDoesNotExist();
@@ -79,6 +79,10 @@ library InteractionLogic {
                     profileIds[i],
                     followModuleDatas[i]
                 );
+            }
+
+            unchecked {
+                i++;
             }
         }
     }

--- a/contracts/libraries/ProfileTokenURILogic.sol
+++ b/contracts/libraries/ProfileTokenURILogic.sol
@@ -144,13 +144,17 @@ library ProfileTokenURILogic {
      */
     function _shouldUseCustomPicture(string memory imageURI) internal pure returns (bool) {
         bytes memory imageURIBytes = bytes(imageURI);
-        if (imageURIBytes.length == 0) {
+        uint256 imageURIBytesLength = imageURIBytes.length;
+        if (imageURIBytesLength == 0) {
             return false;
         }
-        for (uint256 i = 0; i < imageURIBytes.length; i++) {
+        for (uint256 i; i < imageURIBytesLength; ) {
             if (imageURIBytes[i] == '"') {
                 // Avoids embedding a user provided imageURI containing double-quotes to prevent injection attacks
                 return false;
+            }
+            unchecked {
+                i++;
             }
         }
         return true;

--- a/contracts/libraries/PublishingLogic.sol
+++ b/contracts/libraries/PublishingLogic.sol
@@ -397,10 +397,11 @@ library PublishingLogic {
 
     function _validateHandle(string calldata handle) private pure {
         bytes memory byteHandle = bytes(handle);
-        if (byteHandle.length == 0 || byteHandle.length > Constants.MAX_HANDLE_LENGTH)
+        uint256 byteHandleLength = byteHandle.length;
+        if (byteHandleLength == 0 || byteHandleLength > Constants.MAX_HANDLE_LENGTH)
             revert Errors.HandleLengthInvalid();
 
-        for (uint256 i = 0; i < byteHandle.length; ++i) {
+        for (uint256 i; i < byteHandleLength; ) {
             if (
                 (byteHandle[i] < '0' ||
                     byteHandle[i] > 'z' ||
@@ -409,6 +410,9 @@ library PublishingLogic {
                 byteHandle[i] != '-' &&
                 byteHandle[i] != '_'
             ) revert Errors.HandleContainsInvalidCharacters();
+            unchecked {
+                i++;
+            }
         }
     }
 }

--- a/contracts/misc/LensPeripheryDataProvider.sol
+++ b/contracts/misc/LensPeripheryDataProvider.sol
@@ -14,7 +14,7 @@ import {Errors} from '../libraries/Errors.sol';
  *
  * @dev This is useful because it allows clients to filter out follow NFTs that were transferred to
  * a recipient by another user (i.e. Not a mint) and not register them as "following" unless
- * the recipient explicitly toggles the follow here. 
+ * the recipient explicitly toggles the follow here.
  */
 contract LensPeripheryDataProvider {
     string public constant NAME = 'LensPeripheryDataProvider';
@@ -78,12 +78,16 @@ contract LensPeripheryDataProvider {
         uint256[] calldata profileIds,
         bool[] calldata enables
     ) internal {
-        if (profileIds.length != enables.length) revert Errors.ArrayMismatch();
-        for (uint256 i = 0; i < profileIds.length; ++i) {
+        uint256 profileIdsLength = profileIds.length;
+        if (profileIdsLength != enables.length) revert Errors.ArrayMismatch();
+        for (uint256 i; i < profileIdsLength; ) {
             address followNFT = HUB.getFollowNFT(profileIds[i]);
             if (followNFT == address(0)) revert Errors.FollowInvalid();
             if (!IERC721Time(address(HUB)).exists(profileIds[i])) revert Errors.TokenDoesNotExist();
             if (IERC721Time(followNFT).balanceOf(follower) == 0) revert Errors.FollowInvalid();
+            unchecked {
+                i++;
+            }
         }
         emit Events.FollowsToggled(follower, profileIds, enables, block.timestamp);
     }


### PR DESCRIPTION
## Context

This pull request suggests minor optimizations for for-loops. 

## Description

Here's the list of optimizations I did:
- Caching the array's length before processing the loop. In for-loops, checking the length of an array on every iteration costs extra gas per iteration. We can avoid that simply by caching the length before the loop.
- Removing the assignment of the iterator to 0. As 0 is the default value, we don't have to set it manually.
- Incrementing iterator inside an unchecked block. As there is no way the iterator will over/underflow, the automatic checking introduced by the 0.8 version is overkill.

## Gas snapshots

### Before

```bash
·-------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                    Solc version: 0.8.10                     ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 12450000 gas  │
······························································|···························|·············|······························
|  Methods                                                    ·               92 gwei/gas               ·       3114.32 eur/eth       │
································|·····························|·············|·············|·············|···············|··············
|  Contract                     ·  Method                     ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
································|·····························|·············|·············|·············|···············|··············
|  ApprovalFollowModule         ·  approve                    ·      41030  ·      62942  ·      60950  ·           11  ·      17.46  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  burn                       ·      65782  ·      71373  ·      66914  ·            8  ·      19.17  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  burnWithSig                ·          -  ·          -  ·      90655  ·            1  ·      25.97  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  permit                     ·          -  ·          -  ·      87613  ·            1  ·      25.10  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  permitForAll               ·      61063  ·      85622  ·      66728  ·           15  ·      19.12  │
································|·····························|·············|·············|·············|···············|··············
|  Currency                     ·  approve                    ·      46556  ·      46568  ·      46564  ·           29  ·      13.34  │
································|·····························|·············|·············|·············|···············|··············
|  Currency                     ·  mint                       ·          -  ·          -  ·      68660  ·           34  ·      19.67  │
································|·····························|·············|·············|·············|···············|··············
|  ERC20                        ·  approve                    ·          -  ·          -  ·      56109  ·            1  ·      16.08  │
································|·····························|·············|·············|·············|···············|··············
|  ERC20                        ·  transferFrom               ·      95889  ·     115350  ·     107137  ·           21  ·      30.70  │
································|·····························|·············|·············|·············|···············|··············
|  FollowNFT                    ·  delegate                   ·      64411  ·     144836  ·     110542  ·           18  ·      31.67  │
································|·····························|·············|·············|·············|···············|··············
|  FollowNFT                    ·  delegateBySig              ·          -  ·          -  ·     176893  ·            1  ·      50.68  │
································|·····························|·············|·············|·············|···············|··············
|  Helper                       ·  batchDelegate              ·          -  ·          -  ·     202666  ·            1  ·      58.07  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  collect                    ·     250249  ·     519147  ·     428900  ·           64  ·     122.89  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  collectWithSig             ·     433178  ·     439924  ·     434865  ·            4  ·     124.60  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  comment                    ·     221918  ·     262157  ·     230575  ·           17  ·      66.06  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  commentWithSig             ·          -  ·          -  ·     254579  ·            3  ·      72.94  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  createProfile              ·     409576  ·     534420  ·     430237  ·          471  ·     123.27  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  follow                     ·     192303  ·     613378  ·     334957  ·          173  ·      95.97  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  followWithSig              ·     397359  ·     523809  ·     428972  ·            4  ·     122.91  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  mirror                     ·      96765  ·     135024  ·     110268  ·           61  ·      31.59  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  mirrorWithSig              ·     128696  ·     135454  ·     130386  ·            4  ·      37.36  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  post                       ·     104469  ·     291513  ·     222701  ·          199  ·      63.81  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  postWithSig                ·          -  ·          -  ·     222545  ·            3  ·      63.76  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDefaultProfile          ·      33186  ·      57394  ·      50509  ·            6  ·      14.47  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDefaultProfileWithSig   ·      48740  ·      90048  ·      74946  ·            5  ·      21.47  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDispatcher              ·          -  ·          -  ·      57960  ·            8  ·      16.61  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDispatcherWithSig       ·          -  ·          -  ·      89613  ·            3  ·      25.68  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setEmergencyAdmin          ·      33578  ·      55718  ·      52028  ·            6  ·      14.91  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowModule            ·      41175  ·     145184  ·      80218  ·           25  ·      22.98  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowModuleWithSig     ·      75092  ·     102381  ·      84188  ·            3  ·      24.12  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowNFTURI            ·          -  ·          -  ·      59237  ·            2  ·      16.97  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowNFTURIWithSig     ·          -  ·          -  ·      91112  ·            2  ·      26.11  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setGovernance              ·          -  ·          -  ·      36669  ·            3  ·      10.51  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setProfileImageURI         ·      45540  ·      82287  ·      59331  ·            6  ·      17.00  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setProfileImageURIWithSig  ·          -  ·          -  ·      88407  ·            3  ·      25.33  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setState                   ·      33558  ·      57601  ·      45869  ·           84  ·      13.14  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistCollectModule     ·      33669  ·      55581  ·      54977  ·          241  ·      15.75  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistFollowModule      ·      33691  ·      55603  ·      54403  ·           55  ·      15.59  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistProfileCreator    ·      33659  ·      55571  ·      49310  ·            7  ·      14.13  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistReferenceModule   ·      33714  ·      55626  ·      53940  ·           39  ·      15.45  │
································|·····························|·············|·············|·············|···············|··············
|  LensPeripheryDataProvider    ·  toggleFollow               ·      51282  ·      65869  ·      56148  ·            6  ·      16.09  │
································|·····························|·············|·············|·············|···············|··············
|  LensPeripheryDataProvider    ·  toggleFollowWithSig        ·      81840  ·      81852  ·      81846  ·            4  ·      23.45  │
································|·····························|·············|·············|·············|···············|··············
|  MockLensHubV2                ·  setAdditionalValue         ·          -  ·          -  ·      50877  ·            1  ·      14.58  │
································|·····························|·············|·············|·············|···············|··············
|  MockProfileCreationProxy     ·  proxyCreateProfile         ·          -  ·          -  ·     434814  ·            1  ·     124.58  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  setGovernance              ·          -  ·          -  ·      28916  ·            3  ·       8.28  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  setTreasury                ·          -  ·          -  ·      30938  ·            3  ·       8.86  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  setTreasuryFee             ·      30703  ·      30715  ·      30705  ·           12  ·       8.80  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  whitelistCurrency          ·      26683  ·      48595  ·      48157  ·          100  ·      13.80  │
································|·····························|·············|·············|·············|···············|··············
|  TransparentUpgradeableProxy  ·  changeAdmin                ·          -  ·          -  ·      28672  ·            1  ·       8.22  │
································|·····························|·············|·············|·············|···············|··············
|  TransparentUpgradeableProxy  ·  upgradeTo                  ·          -  ·          -  ·      33000  ·            4  ·       9.46  │
································|·····························|·············|·············|·············|···············|··············
|  Deployments                                                ·                                         ·  % of limit   ·             │
······························································|·············|·············|·············|···············|··············
|  ApprovalFollowModule                                       ·          -  ·          -  ·     895672  ·        7.2 %  ·     256.63  │
······························································|·············|·············|·············|···············|··············
|  CollectNFT                                                 ·          -  ·          -  ·    2086865  ·       16.8 %  ·     597.92  │
······························································|·············|·············|·············|···············|··············
|  Currency                                                   ·          -  ·          -  ·     648079  ·        5.2 %  ·     185.69  │
······························································|·············|·············|·············|···············|··············
|  EmptyCollectModule                                         ·          -  ·          -  ·     386710  ·        3.1 %  ·     110.80  │
······························································|·············|·············|·············|···············|··············
|  Events                                                     ·          -  ·          -  ·      72217  ·        0.6 %  ·      20.69  │
······························································|·············|·············|·············|···············|··············
|  FeeCollectModule                                           ·          -  ·          -  ·     999103  ·          8 %  ·     286.26  │
······························································|·············|·············|·············|···············|··············
|  FeeFollowModule                                            ·          -  ·          -  ·     822100  ·        6.6 %  ·     235.55  │
······························································|·············|·············|·············|···············|··············
|  FollowerOnlyReferenceModule                                ·          -  ·          -  ·     394679  ·        3.2 %  ·     113.08  │
······························································|·············|·············|·············|···············|··············
|  FollowNFT                                                  ·          -  ·          -  ·    2649166  ·       21.3 %  ·     759.03  │
······························································|·············|·············|·············|···············|··············
|  Helper                                                     ·          -  ·          -  ·     148063  ·        1.2 %  ·      42.42  │
······························································|·············|·············|·············|···············|··············
|  InteractionLogic                                           ·          -  ·          -  ·     988528  ·        7.9 %  ·     283.23  │
······························································|·············|·············|·············|···············|··············
|  LensHub                                                    ·    5251452  ·    5251932  ·    5251644  ·       42.2 %  ·    1504.69  │
······························································|·············|·············|·············|···············|··············
|  LensPeripheryDataProvider                                  ·          -  ·          -  ·     671883  ·        5.4 %  ·     192.51  │
······························································|·············|·············|·············|···············|··············
|  LimitedFeeCollectModule                                    ·          -  ·          -  ·    1048559  ·        8.4 %  ·     300.43  │
······························································|·············|·············|·············|···············|··············
|  LimitedTimedFeeCollectModule                               ·          -  ·          -  ·    1156982  ·        9.3 %  ·     331.50  │
······························································|·············|·············|·············|···············|··············
|  MockFollowModule                                           ·          -  ·          -  ·     241136  ·        1.9 %  ·      69.09  │
······························································|·············|·············|·············|···············|··············
|  MockLensHubV2                                              ·          -  ·          -  ·    1870060  ·         15 %  ·     535.80  │
······························································|·············|·············|·············|···············|··············
|  MockLensHubV2BadRevision                                   ·          -  ·          -  ·    1870060  ·         15 %  ·     535.80  │
······························································|·············|·············|·············|···············|··············
|  MockProfileCreationProxy                                   ·          -  ·          -  ·     202333  ·        1.6 %  ·      57.97  │
······························································|·············|·············|·············|···············|··············
|  MockReferenceModule                                        ·          -  ·          -  ·     181657  ·        1.5 %  ·      52.05  │
······························································|·············|·············|·············|···············|··············
|  ModuleGlobals                                              ·          -  ·          -  ·     427782  ·        3.4 %  ·     122.57  │
······························································|·············|·············|·············|···············|··············
|  ProfileTokenURILogic                                       ·          -  ·          -  ·    3886763  ·       31.2 %  ·    1113.63  │
······························································|·············|·············|·············|···············|··············
|  PublishingLogic                                            ·          -  ·          -  ·    1359842  ·       10.9 %  ·     389.62  │
······························································|·············|·············|·············|···············|··············
|  RevertCollectModule                                        ·          -  ·          -  ·     179713  ·        1.4 %  ·      51.49  │
······························································|·············|·············|·············|···············|··············
|  TimedFeeCollectModule                                      ·          -  ·          -  ·    1046020  ·        8.4 %  ·     299.70  │
······························································|·············|·············|·············|···············|··············
|  TransparentUpgradeableProxy                                ·          -  ·          -  ·     719891  ·        5.8 %  ·     206.26  │
······························································|·············|·············|·············|···············|··············
|  UIDataProvider                                             ·          -  ·          -  ·     565263  ·        4.5 %  ·     161.96  │
·-------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

### After
 
```bash
·-------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                    Solc version: 0.8.10                     ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 12450000 gas  │
······························································|···························|·············|······························
|  Methods                                                    ·               72 gwei/gas               ·       3101.81 eur/eth       │
································|·····························|·············|·············|·············|···············|··············
|  Contract                     ·  Method                     ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
································|·····························|·············|·············|·············|···············|··············
|  ApprovalFollowModule         ·  approve                    ·      40966  ·      62878  ·      60886  ·           11  ·      13.60  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  burn                       ·      65782  ·      71373  ·      66914  ·            8  ·      14.94  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  burnWithSig                ·          -  ·          -  ·      90655  ·            1  ·      20.25  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  permit                     ·          -  ·          -  ·      87613  ·            1  ·      19.57  │
································|·····························|·············|·············|·············|···············|··············
|  CollectNFT                   ·  permitForAll               ·      61063  ·      85622  ·      66728  ·           15  ·      14.90  │
································|·····························|·············|·············|·············|···············|··············
|  Currency                     ·  approve                    ·      46556  ·      46568  ·      46564  ·           29  ·      10.40  │
································|·····························|·············|·············|·············|···············|··············
|  Currency                     ·  mint                       ·          -  ·          -  ·      68660  ·           34  ·      15.33  │
································|·····························|·············|·············|·············|···············|··············
|  ERC20                        ·  approve                    ·          -  ·          -  ·      56109  ·            1  ·      12.53  │
································|·····························|·············|·············|·············|···············|··············
|  ERC20                        ·  transferFrom               ·      95889  ·     115350  ·     107137  ·           21  ·      23.93  │
································|·····························|·············|·············|·············|···············|··············
|  FollowNFT                    ·  delegate                   ·      64411  ·     144836  ·     110542  ·           18  ·      24.69  │
································|·····························|·············|·············|·············|···············|··············
|  FollowNFT                    ·  delegateBySig              ·          -  ·          -  ·     176893  ·            1  ·      39.51  │
································|·····························|·············|·············|·············|···············|··············
|  Helper                       ·  batchDelegate              ·          -  ·          -  ·     202666  ·            1  ·      45.26  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  collect                    ·     250249  ·     519147  ·     428900  ·           64  ·      95.79  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  collectWithSig             ·     433178  ·     439924  ·     434865  ·            4  ·      97.12  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  comment                    ·     221926  ·     262165  ·     230583  ·           17  ·      51.50  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  commentWithSig             ·          -  ·          -  ·     254587  ·            3  ·      56.86  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  createProfile              ·     409284  ·     533336  ·     429226  ·          471  ·      95.86  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  follow                     ·     192303  ·     613378  ·     334957  ·          173  ·      74.81  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  followWithSig              ·     397097  ·     523272  ·     428641  ·            4  ·      95.73  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  mirror                     ·      96765  ·     135024  ·     110268  ·           61  ·      24.63  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  mirrorWithSig              ·     128696  ·     135454  ·     130386  ·            4  ·      29.12  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  post                       ·     104477  ·     291521  ·     222709  ·          199  ·      49.74  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  postWithSig                ·          -  ·          -  ·     222553  ·            3  ·      49.70  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDefaultProfile          ·      33186  ·      57394  ·      50509  ·            6  ·      11.28  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDefaultProfileWithSig   ·      48740  ·      90048  ·      74946  ·            5  ·      16.74  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDispatcher              ·          -  ·          -  ·      57960  ·            8  ·      12.94  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setDispatcherWithSig       ·          -  ·          -  ·      89613  ·            3  ·      20.01  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setEmergencyAdmin          ·      33578  ·      55718  ·      52028  ·            6  ·      11.62  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowModule            ·      41175  ·     145184  ·      80203  ·           25  ·      17.91  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowModuleWithSig     ·      75092  ·     102381  ·      84188  ·            3  ·      18.80  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowNFTURI            ·          -  ·          -  ·      59237  ·            2  ·      13.23  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setFollowNFTURIWithSig     ·          -  ·          -  ·      91112  ·            2  ·      20.35  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setGovernance              ·          -  ·          -  ·      36669  ·            3  ·       8.19  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setProfileImageURI         ·      45540  ·      82287  ·      59331  ·            6  ·      13.25  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setProfileImageURIWithSig  ·          -  ·          -  ·      88407  ·            3  ·      19.74  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  setState                   ·      33558  ·      57601  ·      45869  ·           84  ·      10.24  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistCollectModule     ·      33669  ·      55581  ·      54977  ·          241  ·      12.28  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistFollowModule      ·      33691  ·      55603  ·      54403  ·           55  ·      12.15  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistProfileCreator    ·      33659  ·      55571  ·      49310  ·            7  ·      11.01  │
································|·····························|·············|·············|·············|···············|··············
|  LensHub                      ·  whitelistReferenceModule   ·      33714  ·      55626  ·      53940  ·           39  ·      12.05  │
································|·····························|·············|·············|·············|···············|··············
|  LensPeripheryDataProvider    ·  toggleFollow               ·      51218  ·      65736  ·      56061  ·            6  ·      12.52  │
································|·····························|·············|·············|·············|···············|··············
|  LensPeripheryDataProvider    ·  toggleFollowWithSig        ·      81776  ·      81788  ·      81782  ·            4  ·      18.26  │
································|·····························|·············|·············|·············|···············|··············
|  MockLensHubV2                ·  setAdditionalValue         ·          -  ·          -  ·      50877  ·            1  ·      11.36  │
································|·····························|·············|·············|·············|···············|··············
|  MockProfileCreationProxy     ·  proxyCreateProfile         ·          -  ·          -  ·     433730  ·            1  ·      96.87  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  setGovernance              ·          -  ·          -  ·      28916  ·            3  ·       6.46  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  setTreasury                ·          -  ·          -  ·      30938  ·            3  ·       6.91  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  setTreasuryFee             ·      30703  ·      30715  ·      30705  ·           12  ·       6.86  │
································|·····························|·············|·············|·············|···············|··············
|  ModuleGlobals                ·  whitelistCurrency          ·      26683  ·      48595  ·      48157  ·          100  ·      10.75  │
································|·····························|·············|·············|·············|···············|··············
|  TransparentUpgradeableProxy  ·  changeAdmin                ·          -  ·          -  ·      28672  ·            1  ·       6.40  │
································|·····························|·············|·············|·············|···············|··············
|  TransparentUpgradeableProxy  ·  upgradeTo                  ·          -  ·          -  ·      33000  ·            4  ·       7.37  │
································|·····························|·············|·············|·············|···············|··············
|  Deployments                                                ·                                         ·  % of limit   ·             │
······························································|·············|·············|·············|···············|··············
|  ApprovalFollowModule                                       ·          -  ·          -  ·     880803  ·        7.1 %  ·     196.71  │
······························································|·············|·············|·············|···············|··············
|  CollectNFT                                                 ·          -  ·          -  ·    2086865  ·       16.8 %  ·     466.06  │
······························································|·············|·············|·············|···············|··············
|  Currency                                                   ·          -  ·          -  ·     648079  ·        5.2 %  ·     144.74  │
······························································|·············|·············|·············|···············|··············
|  EmptyCollectModule                                         ·          -  ·          -  ·     386710  ·        3.1 %  ·      86.36  │
······························································|·············|·············|·············|···············|··············
|  Events                                                     ·          -  ·          -  ·      72217  ·        0.6 %  ·      16.13  │
······························································|·············|·············|·············|···············|··············
|  FeeCollectModule                                           ·          -  ·          -  ·     999103  ·          8 %  ·     223.13  │
······························································|·············|·············|·············|···············|··············
|  FeeFollowModule                                            ·          -  ·          -  ·     822100  ·        6.6 %  ·     183.60  │
······························································|·············|·············|·············|···············|··············
|  FollowerOnlyReferenceModule                                ·          -  ·          -  ·     394679  ·        3.2 %  ·      88.14  │
······························································|·············|·············|·············|···············|··············
|  FollowNFT                                                  ·          -  ·          -  ·    2649166  ·       21.3 %  ·     591.64  │
······························································|·············|·············|·············|···············|··············
|  Helper                                                     ·          -  ·          -  ·     148063  ·        1.2 %  ·      33.07  │
······························································|·············|·············|·············|···············|··············
|  InteractionLogic                                           ·          -  ·          -  ·     988528  ·        7.9 %  ·     220.77  │
······························································|·············|·············|·············|···············|··············
|  LensHub                                                    ·    5262234  ·    5262714  ·    5262426  ·       42.3 %  ·    1175.26  │
······························································|·············|·············|·············|···············|··············
|  LensPeripheryDataProvider                                  ·          -  ·          -  ·     670563  ·        5.4 %  ·     149.76  │
······························································|·············|·············|·············|···············|··············
|  LimitedFeeCollectModule                                    ·          -  ·          -  ·    1048559  ·        8.4 %  ·     234.18  │
······························································|·············|·············|·············|···············|··············
|  LimitedTimedFeeCollectModule                               ·          -  ·          -  ·    1156982  ·        9.3 %  ·     258.39  │
······························································|·············|·············|·············|···············|··············
|  MockFollowModule                                           ·          -  ·          -  ·     241136  ·        1.9 %  ·      53.85  │
······························································|·············|·············|·············|···············|··············
|  MockLensHubV2                                              ·          -  ·          -  ·    1870060  ·         15 %  ·     417.64  │
······························································|·············|·············|·············|···············|··············
|  MockLensHubV2BadRevision                                   ·          -  ·          -  ·    1870060  ·         15 %  ·     417.64  │
······························································|·············|·············|·············|···············|··············
|  MockProfileCreationProxy                                   ·          -  ·          -  ·     202333  ·        1.6 %  ·      45.19  │
······························································|·············|·············|·············|···············|··············
|  MockReferenceModule                                        ·          -  ·          -  ·     181657  ·        1.5 %  ·      40.57  │
······························································|·············|·············|·············|···············|··············
|  ModuleGlobals                                              ·          -  ·          -  ·     427782  ·        3.4 %  ·      95.54  │
······························································|·············|·············|·············|···············|··············
|  ProfileTokenURILogic                                       ·          -  ·          -  ·    3885248  ·       31.2 %  ·     867.69  │
······························································|·············|·············|·············|···············|··············
|  PublishingLogic                                            ·          -  ·          -  ·    1349956  ·       10.8 %  ·     301.49  │
······························································|·············|·············|·············|···············|··············
|  RevertCollectModule                                        ·          -  ·          -  ·     179713  ·        1.4 %  ·      40.14  │
······························································|·············|·············|·············|···············|··············
|  TimedFeeCollectModule                                      ·          -  ·          -  ·    1046020  ·        8.4 %  ·     233.61  │
······························································|·············|·············|·············|···············|··············
|  TransparentUpgradeableProxy                                ·          -  ·          -  ·     719891  ·        5.8 %  ·     160.77  │
······························································|·············|·············|·············|···············|··············
|  UIDataProvider                                             ·          -  ·          -  ·     565263  ·        4.5 %  ·     126.24  │
·-------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```