### PR TITLE
refacto: don't init for-loop iterators

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -534,7 +534,7 @@ contract LensHub is ILensHub, LensNFTBase, VersionedInitializable, LensMultiStat
     {
         uint256 dataLength = vars.datas.length;
         bytes32[] memory dataHashes = new bytes32[](dataLength);
-        for (uint256 i = 0; i < dataLength; ) {
+        for (uint256 i; i < dataLength; ) {
             dataHashes[i] = keccak256(vars.datas[i]);
             unchecked {
                 ++i;

--- a/contracts/core/modules/follow/ApprovalFollowModule.sol
+++ b/contracts/core/modules/follow/ApprovalFollowModule.sol
@@ -39,7 +39,7 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
         if (msg.sender != owner) revert Errors.NotProfileOwner();
 
         uint256 addressesLength = addresses.length;
-        for (uint256 i = 0; i < addressesLength; ) {
+        for (uint256 i; i < addressesLength; ) {
             _approvedByProfileByOwner[owner][profileId][addresses[i]] = toApprove[i];
             unchecked {
                 ++i;
@@ -69,7 +69,7 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
         if (data.length > 0) {
             address[] memory addresses = abi.decode(data, (address[]));
             uint256 addressesLength = addresses.length;
-            for (uint256 i = 0; i < addressesLength; ) {
+            for (uint256 i; i < addressesLength; ) {
                 _approvedByProfileByOwner[owner][profileId][addresses[i]] = true;
                 unchecked {
                     ++i;
@@ -137,7 +137,7 @@ contract ApprovalFollowModule is IFollowModule, FollowValidatorFollowModuleBase 
     ) external view returns (bool[] memory) {
         bool[] memory approved = new bool[](toCheck.length);
         uint256 toCheckLength = toCheck.length;
-        for (uint256 i = 0; i < toCheckLength; ) {
+        for (uint256 i; i < toCheckLength; ) {
             approved[i] = _approvedByProfileByOwner[profileOwner][profileId][toCheck[i]];
             unchecked {
                 ++i;

--- a/contracts/libraries/InteractionLogic.sol
+++ b/contracts/libraries/InteractionLogic.sol
@@ -45,7 +45,7 @@ library InteractionLogic {
         mapping(bytes32 => uint256) storage _profileIdByHandleHash
     ) external {
         if (profileIds.length != followModuleDatas.length) revert Errors.ArrayMismatch();
-        for (uint256 i = 0; i < profileIds.length; ) {
+        for (uint256 i; i < profileIds.length; ) {
             string memory handle = _profileById[profileIds[i]].handle;
             if (_profileIdByHandleHash[keccak256(bytes(handle))] != profileIds[i])
                 revert Errors.TokenDoesNotExist();

--- a/contracts/libraries/ProfileTokenURILogic.sol
+++ b/contracts/libraries/ProfileTokenURILogic.sol
@@ -148,7 +148,7 @@ library ProfileTokenURILogic {
             return false;
         }
         uint256 imageURIBytesLength = imageURIBytes.length;
-        for (uint256 i = 0; i < imageURIBytesLength; ) {
+        for (uint256 i; i < imageURIBytesLength; ) {
             if (imageURIBytes[i] == '"') {
                 // Avoids embedding a user provided imageURI containing double-quotes to prevent injection attacks
                 return false;

--- a/contracts/libraries/PublishingLogic.sol
+++ b/contracts/libraries/PublishingLogic.sol
@@ -405,7 +405,7 @@ library PublishingLogic {
             revert Errors.HandleLengthInvalid();
 
         uint256 byteHandleLength = byteHandle.length;
-        for (uint256 i = 0; i < byteHandleLength; ) {
+        for (uint256 i; i < byteHandleLength; ) {
             if (
                 (byteHandle[i] < '0' ||
                     byteHandle[i] > 'z' ||

--- a/contracts/misc/LensPeriphery.sol
+++ b/contracts/misc/LensPeriphery.sol
@@ -80,7 +80,7 @@ contract LensPeriphery {
     ) internal {
         if (profileIds.length != enables.length) revert Errors.ArrayMismatch();
         uint256 profileIdsLength = profileIds.length;
-        for (uint256 i = 0; i < profileIdsLength; ) {
+        for (uint256 i; i < profileIdsLength; ) {
             address followNFT = HUB.getFollowNFT(profileIds[i]);
             if (followNFT == address(0)) revert Errors.FollowInvalid();
             if (!IERC721Time(address(HUB)).exists(profileIds[i])) revert Errors.TokenDoesNotExist();


### PR DESCRIPTION
As 0 is already the default value for uint* variables, setting it to 0 is unnecessary.