### PR TITLE
ProfileFollowModule implementation added

### DIFF
--- a/contracts/core/modules/follow/ProfileFollowModule.sol
+++ b/contracts/core/modules/follow/ProfileFollowModule.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {IFollowModule} from '../../../interfaces/IFollowModule.sol';
+import {Errors} from '../../../libraries/Errors.sol';
+import {Events} from '../../../libraries/Events.sol';
+import {ModuleBase} from '../ModuleBase.sol';
+import {FollowValidatorFollowModuleBase} from './FollowValidatorFollowModuleBase.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+
+/**
+ * @title ProfileFollowModule
+ * @author Lens Protocol
+ *
+ * @notice This follow module only allows profiles that are not already following in the current revision to follow.
+ */
+contract ProfileFollowModule is IFollowModule, FollowValidatorFollowModuleBase {
+    mapping(uint256 => mapping(uint256 => mapping(uint256 => bool)))
+        internal _isProfileFollowingByRevisionByProfile;
+
+    mapping(uint256 => uint256) internal _revisionByProfile;
+
+    constructor(address hub) ModuleBase(hub) {}
+
+    /**
+     * @notice This follow module works on custom profile owner approvals.
+     *
+     * @param profileId The profile ID of the profile to initialize this module for.
+     * @param data The arbitrary data parameter, decoded into:
+     *      uint256 revision: The revision number to be used in this module initialization.
+     *
+     * @return bytes An abi encoded bytes parameter, which is the same as the passed data parameter.
+     */
+    function initializeFollowModule(uint256 profileId, bytes calldata data)
+        external
+        override
+        onlyHub
+        returns (bytes memory)
+    {
+        _revisionByProfile[profileId] = abi.decode(data, (uint256));
+        return data;
+    }
+
+    /**
+     * @dev Processes a follow by:
+     *  1. Follower owns the profile passed through the data param.
+     *  2. The profile that is executing the follow is not already following the other profile in the current revision.
+     */
+    function processFollow(
+        address follower,
+        uint256 profileId,
+        bytes calldata data
+    ) external override onlyHub {
+        uint256 followerProfileId = abi.decode(data, (uint256));
+        if (IERC721(HUB).ownerOf(followerProfileId) != follower) {
+            revert Errors.NotProfileOwner();
+        }
+        uint256 revision = _revisionByProfile[profileId];
+        if (_isProfileFollowingByRevisionByProfile[profileId][revision][followerProfileId]) {
+            revert Errors.FollowInvalid();
+        } else {
+            _isProfileFollowingByRevisionByProfile[profileId][revision][followerProfileId] = true;
+        }
+    }
+
+    /**
+     * @dev We don't need to execute any additional logic on transfers in this follow module.
+     */
+    function followModuleTransferHook(
+        uint256 profileId,
+        address from,
+        address to,
+        uint256 followNFTTokenId
+    ) external override {}
+}

--- a/contracts/core/modules/follow/ProfileFollowModule.sol
+++ b/contracts/core/modules/follow/ProfileFollowModule.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.10;
 
 import {IFollowModule} from '../../../interfaces/IFollowModule.sol';
 import {Errors} from '../../../libraries/Errors.sol';
-import {Events} from '../../../libraries/Events.sol';
 import {ModuleBase} from '../ModuleBase.sol';
 import {FollowValidatorFollowModuleBase} from './FollowValidatorFollowModuleBase.sol';
 import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';

--- a/contracts/core/modules/follow/ProfileFollowModule.sol
+++ b/contracts/core/modules/follow/ProfileFollowModule.sol
@@ -44,7 +44,7 @@ contract ProfileFollowModule is IFollowModule, FollowValidatorFollowModuleBase {
     /**
      * @dev Processes a follow by:
      *  1. Validating that the follower owns the profile passed through the data param
-     *  2. TValidating that the profile that being used to execute the follow is not already following
+     *  2. Validating that the profile that is being used to execute the follow is not already following
      *     the given profile in the current revision
      */
     function processFollow(

--- a/contracts/core/modules/follow/ProfileFollowModule.sol
+++ b/contracts/core/modules/follow/ProfileFollowModule.sol
@@ -43,8 +43,9 @@ contract ProfileFollowModule is IFollowModule, FollowValidatorFollowModuleBase {
 
     /**
      * @dev Processes a follow by:
-     *  1. Follower owns the profile passed through the data param.
-     *  2. The profile that is executing the follow is not already following the other profile in the current revision.
+     *  1. Validating that the follower owns the profile passed through the data param
+     *  2. TValidating that the profile that being used to execute the follow is not already following
+     *     the given profile in the current revision
      */
     function processFollow(
         address follower,

--- a/tasks/full-deploy-verify.ts
+++ b/tasks/full-deploy-verify.ts
@@ -22,6 +22,7 @@ import {
   TransparentUpgradeableProxy__factory,
   ProfileTokenURILogic__factory,
   LensPeriphery__factory,
+  ProfileFollowModule__factory,
 } from '../typechain-types';
 import { deployWithVerify, waitForTx } from './helpers/utils';
 
@@ -222,6 +223,14 @@ task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verif
       [lensHub.address, moduleGlobals.address],
       'contracts/core/modules/follow/FeeFollowModule.sol:FeeFollowModule'
     );
+    console.log('\n\t-- Deploying profileFollowModule --');
+    const profileFollowModule = await deployWithVerify(
+      new ProfileFollowModule__factory(deployer).deploy(lensHub.address, {
+        nonce: deployerNonce++,
+      }),
+      [lensHub.address],
+      'contracts/core/modules/follow/ProfileFollowModule.sol:ProfileFollowModule'
+    );
     // --- COMMENTED OUT AS THIS IS NOT A LAUNCH MODULE ---
     // console.log('\n\t-- Deploying approvalFollowModule --');
     // const approvalFollowModule = await deployWithVerify(
@@ -277,6 +286,9 @@ task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verif
     await waitForTx(
       lensHub.whitelistFollowModule(feeFollowModule.address, true, { nonce: governanceNonce++ })
     );
+    await waitForTx(
+      lensHub.whitelistFollowModule(profileFollowModule.address, true, { nonce: governanceNonce++ })
+    );
     // --- COMMENTED OUT AS THIS IS NOT A LAUNCH MODULE ---
     // await waitForTx(
     // lensHub.whitelistFollowModule(approvalFollowModule.address, true, {
@@ -308,8 +320,9 @@ task('full-deploy-verify', 'deploys the entire Lens Protocol with explorer verif
       'timed fee collect module': timedFeeCollectModule.address,
       'limited timed fee collect module': limitedTimedFeeCollectModule.address,
       'revert collect module': revertCollectModule.address,
-      'empty collect module': freeCollectModule.address,
+      'free collect module': freeCollectModule.address,
       'fee follow module': feeFollowModule.address,
+      'profile follow module': profileFollowModule.address,
       // --- COMMENTED OUT AS THIS IS NOT A LAUNCH MODULE ---
       // 'approval follow module': approvalFollowModule.address,
       'follower only reference module': followerOnlyReferenceModule.address,

--- a/tasks/full-deploy.ts
+++ b/tasks/full-deploy.ts
@@ -22,6 +22,7 @@ import {
   TransparentUpgradeableProxy__factory,
   ProfileTokenURILogic__factory,
   LensPeriphery__factory,
+  ProfileFollowModule__factory,
 } from '../typechain-types';
 import { deployContract, waitForTx } from './helpers/utils';
 
@@ -120,10 +121,9 @@ task('full-deploy', 'deploys the entire Lens Protocol').setAction(async ({}, hre
   // Connect the hub proxy to the LensHub factory and the governance for ease of use.
   const lensHub = LensHub__factory.connect(proxy.address, governance);
 
-  const lensPeriphery = await new LensPeriphery__factory(deployer).deploy(
-    lensHub.address,
-    { nonce: deployerNonce++ }
-  );
+  const lensPeriphery = await new LensPeriphery__factory(deployer).deploy(lensHub.address, {
+    nonce: deployerNonce++,
+  });
 
   // Currency
   console.log('\n\t-- Deploying Currency --');
@@ -175,6 +175,12 @@ task('full-deploy', 'deploys the entire Lens Protocol').setAction(async ({}, hre
       nonce: deployerNonce++,
     })
   );
+  console.log('\n\t-- Deploying profileFollowModule --');
+  const profileFollowModule = await deployContract(
+    new ProfileFollowModule__factory(deployer).deploy(lensHub.address, {
+      nonce: deployerNonce++,
+    })
+  );
   // --- COMMENTED OUT AS THIS IS NOT A LAUNCH MODULE ---
   // console.log('\n\t-- Deploying approvalFollowModule --');
   // const approvalFollowModule = await deployContract(
@@ -222,6 +228,9 @@ task('full-deploy', 'deploys the entire Lens Protocol').setAction(async ({}, hre
   await waitForTx(
     lensHub.whitelistFollowModule(feeFollowModule.address, true, { nonce: governanceNonce++ })
   );
+  await waitForTx(
+    lensHub.whitelistFollowModule(profileFollowModule.address, true, { nonce: governanceNonce++ })
+  );
   // --- COMMENTED OUT AS THIS IS NOT A LAUNCH MODULE ---
   // await waitForTx(
   // lensHub.whitelistFollowModule(approvalFollowModule.address, true, { nonce: governanceNonce++ })
@@ -259,8 +268,9 @@ task('full-deploy', 'deploys the entire Lens Protocol').setAction(async ({}, hre
     'timed fee collect module': timedFeeCollectModule.address,
     'limited timed fee collect module': limitedTimedFeeCollectModule.address,
     'revert collect module': revertCollectModule.address,
-    'empty collect module': freeCollectModule.address,
+    'free collect module': freeCollectModule.address,
     'fee follow module': feeFollowModule.address,
+    'profile follow module': profileFollowModule.address,
     // --- COMMENTED OUT AS THIS IS NOT A LAUNCH MODULE ---
     // 'approval follow module': approvalFollowModule.address,
     'follower only reference module': followerOnlyReferenceModule.address,

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -46,6 +46,8 @@ import {
   TransparentUpgradeableProxy__factory,
   LensPeriphery,
   LensPeriphery__factory,
+  ProfileFollowModule,
+  ProfileFollowModule__factory,
 } from '../typechain-types';
 import { LensHubLibraryAddresses } from '../typechain-types/factories/LensHub__factory';
 import { FAKE_PRIVATEKEY, ZERO_ADDRESS } from './helpers/constants';
@@ -113,6 +115,7 @@ export let limitedTimedFeeCollectModule: LimitedTimedFeeCollectModule;
 
 // Follow
 export let approvalFollowModule: ApprovalFollowModule;
+export let profileFollowModule: ProfileFollowModule;
 export let feeFollowModule: FeeFollowModule;
 export let mockFollowModule: MockFollowModule;
 
@@ -228,6 +231,7 @@ before(async function () {
     lensHub.address,
     moduleGlobals.address
   );
+  profileFollowModule = await new ProfileFollowModule__factory(deployer).deploy(lensHub.address);
   approvalFollowModule = await new ApprovalFollowModule__factory(deployer).deploy(lensHub.address);
   followerOnlyReferenceModule = await new FollowerOnlyReferenceModule__factory(deployer).deploy(
     lensHub.address

--- a/test/modules/collect/fee-collect-module.spec.ts
+++ b/test/modules/collect/fee-collect-module.spec.ts
@@ -141,6 +141,14 @@ makeSuiteCleanRoom('Fee Collect Module', function () {
         ).to.not.be.reverted;
       });
 
+      it('UserTwo should fail to process collect without being the hub', async function () {
+        await expect(
+          feeCollectModule
+            .connect(userTwo)
+            .processCollect(0, userTwoAddress, FIRST_PROFILE_ID, 1, [])
+        ).to.be.revertedWith(ERRORS.NOT_HUB);
+      });
+
       it('Governance should set the treasury fee BPS to zero, userTwo collecting should not emit a transfer event to the treasury', async function () {
         await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
         const data = abiCoder.encode(

--- a/test/modules/collect/limited-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-fee-collect-module.spec.ts
@@ -177,6 +177,14 @@ makeSuiteCleanRoom('Limited Fee Collect Module', function () {
         ).to.not.be.reverted;
       });
 
+      it('UserTwo should fail to process collect without being the hub', async function () {
+        await expect(
+          limitedFeeCollectModule
+            .connect(userTwo)
+            .processCollect(0, userTwoAddress, FIRST_PROFILE_ID, 1, [])
+        ).to.be.revertedWith(ERRORS.NOT_HUB);
+      });
+
       it('Governance should set the treasury fee BPS to zero, userTwo collecting should not emit a transfer event to the treasury', async function () {
         await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
         const data = abiCoder.encode(

--- a/test/modules/collect/limited-timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/limited-timed-fee-collect-module.spec.ts
@@ -177,6 +177,14 @@ makeSuiteCleanRoom('Limited Timed Fee Collect Module', function () {
         ).to.not.be.reverted;
       });
 
+      it('UserTwo should fail to process collect without being the hub', async function () {
+        await expect(
+          limitedTimedFeeCollectModule
+            .connect(userTwo)
+            .processCollect(0, userTwoAddress, FIRST_PROFILE_ID, 1, [])
+        ).to.be.revertedWith(ERRORS.NOT_HUB);
+      });
+
       it('Governance should set the treasury fee BPS to zero, userTwo collecting should not emit a transfer event to the treasury', async function () {
         await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
         const data = abiCoder.encode(

--- a/test/modules/collect/timed-fee-collect-module.spec.ts
+++ b/test/modules/collect/timed-fee-collect-module.spec.ts
@@ -138,6 +138,14 @@ makeSuiteCleanRoom('Timed Fee Collect Module', function () {
         ).to.not.be.reverted;
       });
 
+      it('UserTwo should fail to process collect without being the hub', async function () {
+        await expect(
+          timedFeeCollectModule
+            .connect(userTwo)
+            .processCollect(0, userTwoAddress, FIRST_PROFILE_ID, 1, [])
+        ).to.be.revertedWith(ERRORS.NOT_HUB);
+      });
+
       it('Governance should set the treasury fee BPS to zero, userTwo collecting should not emit a transfer event to the treasury', async function () {
         await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
         const data = abiCoder.encode(

--- a/test/modules/follow/approval-follow-module.spec.ts
+++ b/test/modules/follow/approval-follow-module.spec.ts
@@ -67,9 +67,9 @@ makeSuiteCleanRoom('Approval Follow Module', function () {
     });
 
     context('Processing follow', function () {
-      it('Process follow call should fail when sender is not the hub', async function () {
+      it('UserTwo should fail to process follow without being the hub', async function () {
         await expect(
-          approvalFollowModule.processFollow(userTwoAddress, FIRST_PROFILE_ID, [])
+          approvalFollowModule.connect(userTwo).processFollow(userTwoAddress, FIRST_PROFILE_ID, [])
         ).to.be.revertedWith(ERRORS.NOT_HUB);
       });
 

--- a/test/modules/follow/fee-follow-module.spec.ts
+++ b/test/modules/follow/fee-follow-module.spec.ts
@@ -113,6 +113,12 @@ makeSuiteCleanRoom('Fee Follow Module', function () {
         ).to.not.be.reverted;
       });
 
+      it('UserTwo should fail to process follow without being the hub', async function () {
+        await expect(
+          feeFollowModule.connect(userTwo).processFollow(userTwoAddress, FIRST_PROFILE_ID, [])
+        ).to.be.revertedWith(ERRORS.NOT_HUB);
+      });
+
       it('Governance should set the treasury fee BPS to zero, userTwo following should not emit a transfer event to the treasury', async function () {
         await expect(moduleGlobals.connect(governance).setTreasuryFee(0)).to.not.be.reverted;
         const data = abiCoder.encode(

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -199,7 +199,11 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
   context('Scenarios', function () {
     context('Initialization', function () {
       it('Initialize call should succeed returning passed data if it is holding the revision number encoded', async function () {
-        // TODO
+        expect(
+          await profileFollowModule
+            .connect(lensHub.address)
+            .callStatic.initializeFollowModule(FIRST_PROFILE_ID, DEFAULT_INIT_DATA)
+        ).to.eq(DEFAULT_INIT_DATA);
       });
 
       it('Profile creation using profile follow module should succeed and emit expected event', async function () {

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -33,7 +33,7 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
     ).to.not.be.reverted;
   });
 
-  context.only('Negatives', function () {
+  context('Negatives', function () {
     context('Initialization', function () {
       it('Initialize call should fail when sender is not the hub', async function () {
         await expect(
@@ -195,7 +195,7 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
     });
   });
 
-  context.only('Scenarios', function () {
+  context('Scenarios', function () {
     context('Initialization', function () {
       it('Initialize call should succeed returning passed data if it is holding the revision number encoded', async function () {
         // TODO

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -201,7 +201,7 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
         // TODO
       });
 
-      it('Profile creation should succeed and emit expected event', async function () {
+      it('Profile creation using profile follow module should succeed and emit expected event', async function () {
         const tx = lensHub.createProfile({
           to: userAddress,
           handle: MOCK_PROFILE_HANDLE,
@@ -242,6 +242,7 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
           })
         ).to.not.be.reverted;
       });
+
       it('Follow call should work when follower profile exists, is owned by the follower address and has not already followed the profile in the current revision', async function () {
         await expect(
           lensHub.createProfile({

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -1,0 +1,111 @@
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { ZERO_ADDRESS } from '../../helpers/constants';
+import { ERRORS } from '../../helpers/errors';
+import {
+  abiCoder,
+  FIRST_PROFILE_ID,
+  governance,
+  lensHub,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_URI,
+  profileFollowModule,
+  userTwoAddress,
+} from '../../__setup.spec';
+
+makeSuiteCleanRoom('Profile Follow Module', function () {
+  let DEFAULT_INIT_DATA;
+  let DEFAULT_FOLLOW_DATA;
+
+  beforeEach(async function () {
+    DEFAULT_INIT_DATA = abiCoder.encode(['uint256'], [0]);
+    DEFAULT_FOLLOW_DATA = abiCoder.encode(['uint256'], [1]);
+    await expect(
+      lensHub.createProfile({
+        to: userTwoAddress,
+        handle: MOCK_PROFILE_HANDLE,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+    await expect(
+      lensHub.connect(governance).whitelistFollowModule(profileFollowModule.address, true)
+    ).to.not.be.reverted;
+  });
+
+  context('Negatives', function () {
+    context.only('Initialization', function () {
+      it('Initialize call should fail when sender is not the hub', async function () {
+        await expect(
+          profileFollowModule.initializeFollowModule(FIRST_PROFILE_ID, DEFAULT_INIT_DATA)
+        ).to.be.revertedWith(ERRORS.NOT_HUB);
+      });
+
+      it('Initialize call should fail when data is not holding the revision number encoded', async function () {
+        await expect(
+          profileFollowModule.connect(lensHub.address).initializeFollowModule(FIRST_PROFILE_ID, [])
+        ).to.be.reverted;
+      });
+    });
+
+    context('Processing follow', function () {
+      it('Process follow call should fail when sender is not the hub', async function () {
+        // TODO
+      });
+
+      it('Follow should fail when data is not holding the follower profile id encoded', async function () {
+        // TODO
+      });
+
+      it('Follow should fail when the passed follower profile does not exist because has never been minted', async function () {
+        // TODO
+      });
+
+      it('Follow should fail when the passed follower profile does not exist because has been burned', async function () {
+        // TODO
+      });
+
+      it('Follow should fail when follower address is not the owner of the passed follower profile', async function () {
+        // TODO
+      });
+
+      it('Follow should fail when the passed follower profile has already followed the profile in the current revision', async function () {
+        // TODO
+      });
+
+      it('Follow should fail when switching to an old revision where the passed follower profile has alraedy followed the profile', async function () {
+        // TODO
+      });
+
+      it('Follow should fail when the passed follower profile has already followed the profile in the current revision even after the profile nft has been transfered', async function () {
+        // TODO
+      });
+    });
+  });
+
+  context('Scenarios', function () {
+    context('Initialization', function () {
+      it('Initialize call should succeed returning passed data if it is holding the revision number encoded', async function () {
+        // TODO
+      });
+    });
+
+    context('Processing follow', function () {
+      it('Follow call should work when follower profile exists, is owned by the follower address and has not already followed the profile in the current revision', async function () {
+        // TODO
+      });
+
+      it('Follow call should work after changing current revision when if it was already followed before by same profile in other revision', async function () {
+        // TODO
+      });
+
+      it('Follow call should work with each of your profiles when you have more than one', async function () {
+        // TODO
+      });
+    });
+  });
+});

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -52,7 +52,7 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
       });
     });
 
-    context('Processing follow', function () {
+    context('Following', function () {
       it('Process follow call should fail when sender is not the hub', async function () {
         // TODO
       });

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -152,13 +152,14 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
           lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [DEFAULT_FOLLOW_DATA])
         ).to.not.be.reverted;
 
-        // Update the revision and follow again
+        // Update the revision
         const data = abiCoder.encode(['uint256'], [1]);
         await expect(
           lensHub.setFollowModule(FIRST_PROFILE_ID, profileFollowModule.address, data)
         ).to.not.be.reverted;
+        // We check that profile can be followed again but through callStatic to avoid state-changes
         await expect(
-          lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [DEFAULT_FOLLOW_DATA])
+          lensHub.connect(userTwo).callStatic.follow([FIRST_PROFILE_ID], [DEFAULT_FOLLOW_DATA])
         ).to.not.be.reverted;
 
         // Return the revision to the original, follow should be invalid

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -232,6 +232,35 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
           await getTimestamp(),
         ]);
       });
+
+      it('Profile creation using profile follow module should succeed and emit expected event', async function () {
+        await expect(
+          lensHub.createProfile({
+            to: userAddress,
+            handle: MOCK_PROFILE_HANDLE,
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+
+        const tx = lensHub.setFollowModule(
+          FIRST_PROFILE_ID,
+          profileFollowModule.address,
+          DEFAULT_INIT_DATA
+        );
+
+        const receipt = await waitForTx(tx);
+
+        expect(receipt.logs.length).to.eq(1);
+        matchEvent(receipt, 'FollowModuleSet', [
+          FIRST_PROFILE_ID,
+          profileFollowModule.address,
+          DEFAULT_INIT_DATA,
+          await getTimestamp(),
+        ]);
+      });
     });
 
     context('Processing follow', function () {

--- a/test/modules/follow/profile-follow-module.spec.ts
+++ b/test/modules/follow/profile-follow-module.spec.ts
@@ -233,7 +233,7 @@ makeSuiteCleanRoom('Profile Follow Module', function () {
         ]);
       });
 
-      it('Profile creation using profile follow module should succeed and emit expected event', async function () {
+      it('User should create a profile then set the profile follow module as the follow module, correct event should be emitted', async function () {
         await expect(
           lensHub.createProfile({
             to: userAddress,


### PR DESCRIPTION
This follow module only allows profiles that are not already following in the current revision to follow. Ideal for preventing a spammer to dilute the governance power of your followers.