### PR TITLE
Refactor: Simplify Profile Metadata System

### DIFF
--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -353,13 +353,11 @@ library DataTypes {
     /**
      * @notice A struct containing the parameters required for the `setProfileMetadataWithSig()` function.
      *
-     * @param user The user which is the message signer.
      * @param profileId The profile ID for which to set the metadata.
      * @param metadata The metadata string to set for the profile and user.
      * @param sig The EIP712Signature struct containing the user's signature.
      */
     struct SetProfileMetadataWithSigData {
-        address user;
         uint256 profileId;
         string metadata;
         EIP712Signature sig;

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -498,7 +498,7 @@ library Events {
     );
 
     /**
-     * @dev Emitted when the user wants to enable or disable follows in the `LensPeripheryDataProvider`.
+     * @dev Emitted when the user wants to enable or disable follows in the `LensPeriphery`.
      *
      * @param owner The profile owner who executed the toggle.
      * @param profileIds The array of token IDs of the profiles each followNFT is associated with.
@@ -513,15 +513,13 @@ library Events {
     );
 
     /**
-     * @dev Emitted when the metadata associated with a profile and user is set in the `LensPeripheryDataProvider`.
+     * @dev Emitted when the metadata associated with a profile is set in the `LensPeriphery`.
      *
-     * @param user The user the metadata is set for.
      * @param profileId The profile ID the metadata is set for.
      * @param metadata The metadata set for the profile and user.
      * @param timestamp The current block timestamp.
      */
     event ProfileMetadataSet(
-        address indexed user,
         uint256 indexed profileId,
         string metadata,
         uint256 timestamp

--- a/contracts/misc/LensPeriphery.sol
+++ b/contracts/misc/LensPeriphery.sol
@@ -36,43 +36,44 @@ contract LensPeriphery {
 
     mapping(address => uint256) public sigNonces;
 
-    mapping(address => mapping(uint256 => string)) internal _metadataByProfileByOwner;
+    mapping(uint256 => string) internal _metadataByProfile;
 
     constructor(ILensHub hub) {
         HUB = hub;
     }
 
     /**
-     * @notice Sets profile metadata for a profile owner as a dispatcher.
+     * @notice Sets profile metadata for a profile as its dispatcher.
      *
      * @param profileId The profile ID to set the metadata for.
-     * @param metadata The metadata string to set for the profile and owner.
+     * @param metadata The metadata string to set for the profile.
      */
     function dispatcherSetProfileMetadataURI(uint256 profileId, string calldata metadata) external {
-        address owner = IERC721Time(address(HUB)).ownerOf(profileId);
         if (msg.sender != HUB.getDispatcher(profileId)) revert Errors.NotDispatcher();
-        _setProfileMetadataURI(owner, profileId, metadata);
+        _setProfileMetadataURI(profileId, metadata);
     }
 
     /**
-     * @notice Sets the profile metadata for a given profile when owned by the message sender.
+     * @notice Sets the profile metadata for a given profile.
      *
      * @param profileId The profile ID to set the metadata for.
-     * @param metadata The metadata string to set for the profile and message sender.
+     * @param metadata The metadata string to set for the profile.
      */
     function setProfileMetadataURI(uint256 profileId, string calldata metadata) external {
-        _setProfileMetadataURI(msg.sender, profileId, metadata);
+        address owner = IERC721Time(address(HUB)).ownerOf(profileId);
+        if (msg.sender != owner) revert Errors.NotProfileOwner();
+        _setProfileMetadataURI(profileId, metadata);
     }
 
     /**
-     * @notice Sets the profile metadata for a given profile and user via signature with the specified parameters.
+     * @notice Sets the profile metadata for a given profile via signature with the specified parameters.
      *
-     * @param vars A SetProfileMetadataWithSigData struct containingthe regular parameters as well as the user address
-     * and an EIP712Signature struct.
+     * @param vars A SetProfileMetadataWithSigData struct containingthe regular parameters and an EIP712Signature struct.
      */
     function setProfileMetadataURIWithSig(DataTypes.SetProfileMetadataWithSigData calldata vars)
         external
     {
+        address owner = IERC721Time(address(HUB)).ownerOf(vars.profileId);
         _validateRecoveredAddress(
             _calculateDigest(
                 keccak256(
@@ -80,15 +81,15 @@ contract LensPeriphery {
                         SET_PROFILE_METADATA_WITH_SIG_TYPEHASH,
                         vars.profileId,
                         keccak256(bytes(vars.metadata)),
-                        sigNonces[vars.user]++,
+                        sigNonces[owner]++,
                         vars.sig.deadline
                     )
                 )
             ),
-            vars.user,
+            owner,
             vars.sig
         );
-        _setProfileMetadataURI(vars.user, vars.profileId, vars.metadata);
+        _setProfileMetadataURI(vars.profileId, vars.metadata);
     }
 
     /**
@@ -132,39 +133,19 @@ contract LensPeriphery {
     }
 
     /**
-     * @notice Returns the metadata URI of a profile for its current owner.
+     * @notice Returns the metadata URI of a profile.
      *
      * @param profileId The profile ID to query the metadata URI for.
      *
-     * @return string The metadata associated with that profile ID and the profile's current owner.
+     * @return string The metadata associated with that profile ID, or an empty string if it is not set or the profile does not exist.
      */
     function getProfileMetadataURI(uint256 profileId) external view returns (string memory) {
-        address owner = IERC721Time(address(HUB)).ownerOf(profileId);
-        return _metadataByProfileByOwner[owner][profileId];
+        return _metadataByProfile[profileId];
     }
 
-    /**
-     * @notice Returns the metadata URI of a profile for a given user. Note that the user does not *need* to own the
-     * profile in order to have associated metadata.
-     *
-     * @param user The user to query the profile metadata URI for.
-     * @param profileId The profile ID to query the metadata URI for. 
-     */
-    function getProfileMetadataURIByOwner(address user, uint256 profileId)
-        external
-        view
-        returns (string memory)
-    {
-        return _metadataByProfileByOwner[user][profileId];
-    }
-
-    function _setProfileMetadataURI(
-        address user,
-        uint256 profileId,
-        string calldata metadata
-    ) internal {
-        _metadataByProfileByOwner[user][profileId] = metadata;
-        emit Events.ProfileMetadataSet(user, profileId, metadata, block.timestamp);
+    function _setProfileMetadataURI(uint256 profileId, string calldata metadata) internal {
+        _metadataByProfile[profileId] = metadata;
+        emit Events.ProfileMetadataSet(profileId, metadata, block.timestamp);
     }
 
     function _toggleFollow(

--- a/contracts/misc/LensPeriphery.sol
+++ b/contracts/misc/LensPeriphery.sol
@@ -43,25 +43,13 @@ contract LensPeriphery {
     }
 
     /**
-     * @notice Sets profile metadata for a profile as its dispatcher.
-     *
-     * @param profileId The profile ID to set the metadata for.
-     * @param metadata The metadata string to set for the profile.
-     */
-    function dispatcherSetProfileMetadataURI(uint256 profileId, string calldata metadata) external {
-        if (msg.sender != HUB.getDispatcher(profileId)) revert Errors.NotDispatcher();
-        _setProfileMetadataURI(profileId, metadata);
-    }
-
-    /**
      * @notice Sets the profile metadata for a given profile.
      *
      * @param profileId The profile ID to set the metadata for.
      * @param metadata The metadata string to set for the profile.
      */
     function setProfileMetadataURI(uint256 profileId, string calldata metadata) external {
-        address owner = IERC721Time(address(HUB)).ownerOf(profileId);
-        if (msg.sender != owner) revert Errors.NotProfileOwner();
+        _validateCallerIsProfileOwnerOrDispatcher(profileId);
         _setProfileMetadataURI(profileId, metadata);
     }
 
@@ -165,6 +153,16 @@ contract LensPeriphery {
             }
         }
         emit Events.FollowsToggled(follower, profileIds, enables, block.timestamp);
+    }
+
+    function _validateCallerIsProfileOwnerOrDispatcher(uint256 profileId) internal view {
+        if (
+            msg.sender == IERC721Time(address(HUB)).ownerOf(profileId) ||
+            msg.sender == HUB.getDispatcher(profileId)
+        ) {
+            return;
+        }
+        revert Errors.NotProfileOwnerOrDispatcher();
     }
 
     /**

--- a/test/other/misc.spec.ts
+++ b/test/other/misc.spec.ts
@@ -1071,16 +1071,10 @@ makeSuiteCleanRoom('Misc', function () {
         });
 
         context('Negatives', function () {
-          it('User two should fail to set profile metadata URI for a profile that is not theirs', async function () {
+          it('User two should fail to set profile metadata URI for a profile that is not theirs while they are not the dispatcher', async function () {
             await expect(
               lensPeriphery.connect(userTwo).setProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
-            ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER);
-          });
-
-          it("User should fail to set profile metadata URI as dispatcher without being the profile's dispatcher", async function () {
-            await expect(
-              lensPeriphery.dispatcherSetProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
-            ).to.be.revertedWith(ERRORS.NOT_DISPATCHER);
+            ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER_OR_DISPATCHER);
           });
         });
 
@@ -1090,9 +1084,7 @@ makeSuiteCleanRoom('Misc', function () {
               lensHub.setDispatcher(FIRST_PROFILE_ID, userTwoAddress)
             ).to.not.be.reverted;
             await expect(
-              lensPeriphery
-                .connect(userTwo)
-                .dispatcherSetProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
+              lensPeriphery.connect(userTwo).setProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
             ).to.not.be.reverted;
 
             expect(await lensPeriphery.getProfileMetadataURI(FIRST_PROFILE_ID)).to.eq(MOCK_DATA);
@@ -1117,9 +1109,7 @@ makeSuiteCleanRoom('Misc', function () {
             ).to.not.be.reverted;
 
             const tx = await waitForTx(
-              lensPeriphery
-                .connect(userTwo)
-                .dispatcherSetProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
+              lensPeriphery.connect(userTwo).setProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
             );
 
             matchEvent(tx, 'ProfileMetadataSet', [

--- a/test/other/misc.spec.ts
+++ b/test/other/misc.spec.ts
@@ -1071,34 +1071,20 @@ makeSuiteCleanRoom('Misc', function () {
         });
 
         context('Negatives', function () {
+          it('User two should fail to set profile metadata URI for a profile that is not theirs', async function () {
+            await expect(
+              lensPeriphery.connect(userTwo).setProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
+            ).to.be.revertedWith(ERRORS.NOT_PROFILE_OWNER);
+          });
+
           it("User should fail to set profile metadata URI as dispatcher without being the profile's dispatcher", async function () {
             await expect(
               lensPeriphery.dispatcherSetProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
             ).to.be.revertedWith(ERRORS.NOT_DISPATCHER);
           });
-
-          it('Fetching profile metadata for a profile that does not exist yet should fail', async function () {
-            await expect(
-              lensPeriphery.getProfileMetadataURI(FIRST_PROFILE_ID + 1)
-            ).to.be.revertedWith(ERRORS.ERC721_QUERY_FOR_NONEXISTENT_TOKEN);
-          });
         });
 
         context('Scenarios', function () {
-          it('User should set profile metadata for a profile that does not exist, fetched data should be accurate and revert without passing the owner', async function () {
-            const secondProfileId = FIRST_PROFILE_ID + 1;
-            await expect(
-              lensPeriphery.setProfileMetadataURI(secondProfileId, MOCK_DATA)
-            ).to.not.be.reverted;
-
-            expect(
-              await lensPeriphery.getProfileMetadataURIByOwner(userAddress, secondProfileId)
-            ).to.eq(MOCK_DATA);
-            await expect(lensPeriphery.getProfileMetadataURI(secondProfileId)).to.be.revertedWith(
-              ERRORS.ERC721_QUERY_FOR_NONEXISTENT_TOKEN
-            );
-          });
-
           it("User should set user two as dispatcher, user two should set profile metadata URI for user one's profile, fetched data should be accurate", async function () {
             await expect(
               lensHub.setDispatcher(FIRST_PROFILE_ID, userTwoAddress)
@@ -1109,9 +1095,7 @@ makeSuiteCleanRoom('Misc', function () {
                 .dispatcherSetProfileMetadataURI(FIRST_PROFILE_ID, MOCK_DATA)
             ).to.not.be.reverted;
 
-            expect(
-              await lensPeriphery.getProfileMetadataURIByOwner(userAddress, FIRST_PROFILE_ID)
-            ).to.eq(MOCK_DATA);
+            expect(await lensPeriphery.getProfileMetadataURI(FIRST_PROFILE_ID)).to.eq(MOCK_DATA);
             expect(await lensPeriphery.getProfileMetadataURI(FIRST_PROFILE_ID)).to.eq(MOCK_DATA);
           });
 
@@ -1121,7 +1105,6 @@ makeSuiteCleanRoom('Misc', function () {
             );
 
             matchEvent(tx, 'ProfileMetadataSet', [
-              userAddress,
               FIRST_PROFILE_ID,
               MOCK_DATA,
               await getTimestamp(),
@@ -1140,7 +1123,6 @@ makeSuiteCleanRoom('Misc', function () {
             );
 
             matchEvent(tx, 'ProfileMetadataSet', [
-              userAddress,
               FIRST_PROFILE_ID,
               MOCK_DATA,
               await getTimestamp(),
@@ -1175,7 +1157,6 @@ makeSuiteCleanRoom('Misc', function () {
             );
             await expect(
               lensPeriphery.setProfileMetadataURIWithSig({
-                user: testWallet.address,
                 profileId: FIRST_PROFILE_ID,
                 metadata: MOCK_DATA,
                 sig: {
@@ -1199,7 +1180,6 @@ makeSuiteCleanRoom('Misc', function () {
             );
             await expect(
               lensPeriphery.setProfileMetadataURIWithSig({
-                user: testWallet.address,
                 profileId: FIRST_PROFILE_ID,
                 metadata: MOCK_DATA,
                 sig: {
@@ -1223,7 +1203,6 @@ makeSuiteCleanRoom('Misc', function () {
             );
             await expect(
               lensPeriphery.setProfileMetadataURIWithSig({
-                user: testWallet.address,
                 profileId: FIRST_PROFILE_ID,
                 metadata: MOCK_DATA,
                 sig: {
@@ -1249,7 +1228,6 @@ makeSuiteCleanRoom('Misc', function () {
             );
             const tx = await waitForTx(
               lensPeriphery.setProfileMetadataURIWithSig({
-                user: testWallet.address,
                 profileId: FIRST_PROFILE_ID,
                 metadata: MOCK_DATA,
                 sig: {
@@ -1262,12 +1240,9 @@ makeSuiteCleanRoom('Misc', function () {
             );
 
             expect(await lensPeriphery.getProfileMetadataURI(FIRST_PROFILE_ID)).to.eq(MOCK_DATA);
-            expect(
-              await lensPeriphery.getProfileMetadataURIByOwner(testWallet.address, FIRST_PROFILE_ID)
-            ).to.eq(MOCK_DATA);
+            expect(await lensPeriphery.getProfileMetadataURI(FIRST_PROFILE_ID)).to.eq(MOCK_DATA);
 
             matchEvent(tx, 'ProfileMetadataSet', [
-              testWallet.address,
               FIRST_PROFILE_ID,
               MOCK_DATA,
               await getTimestamp(),


### PR DESCRIPTION
This PR simplifies the profile metadata system to be only on a per-profile basis, removing the per-user abstraction layer.