### PR TITLE
Fix: Implement Peckshield Audit Fixes

### DIFF
--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -34,7 +34,6 @@ library Errors {
 
     // Module Errors
     error InitParamsInvalid();
-    error ZeroCurrency();
     error CollectExpired();
     error FollowInvalid();
     error ModuleDataMismatch();

--- a/contracts/libraries/PublishingLogic.sol
+++ b/contracts/libraries/PublishingLogic.sol
@@ -45,11 +45,14 @@ library PublishingLogic {
     ) external {
         _validateHandle(vars.handle);
 
+        if (bytes(vars.imageURI).length > Constants.MAX_PROFILE_IMAGE_URI_LENGTH)
+            revert Errors.ProfileImageURILengthInvalid();
+
         bytes32 handleHash = keccak256(bytes(vars.handle));
 
         if (_profileIdByHandleHash[handleHash] != 0) revert Errors.HandleTaken();
-        _profileIdByHandleHash[handleHash] = profileId;
 
+        _profileIdByHandleHash[handleHash] = profileId;
         _profileById[profileId].handle = vars.handle;
         _profileById[profileId].imageURI = vars.imageURI;
         _profileById[profileId].followNFTURI = vars.followNFTURI;

--- a/contracts/misc/LensPeriphery.sol
+++ b/contracts/misc/LensPeriphery.sol
@@ -61,22 +61,24 @@ contract LensPeriphery {
     function setProfileMetadataURIWithSig(DataTypes.SetProfileMetadataWithSigData calldata vars)
         external
     {
-        address owner = IERC721Time(address(HUB)).ownerOf(vars.profileId);
-        _validateRecoveredAddress(
-            _calculateDigest(
-                keccak256(
-                    abi.encode(
-                        SET_PROFILE_METADATA_WITH_SIG_TYPEHASH,
-                        vars.profileId,
-                        keccak256(bytes(vars.metadata)),
-                        sigNonces[owner]++,
-                        vars.sig.deadline
+        unchecked {
+            address owner = IERC721Time(address(HUB)).ownerOf(vars.profileId);
+            _validateRecoveredAddress(
+                _calculateDigest(
+                    keccak256(
+                        abi.encode(
+                            SET_PROFILE_METADATA_WITH_SIG_TYPEHASH,
+                            vars.profileId,
+                            keccak256(bytes(vars.metadata)),
+                            sigNonces[owner]++,
+                            vars.sig.deadline
+                        )
                     )
-                )
-            ),
-            owner,
-            vars.sig
-        );
+                ),
+                owner,
+                vars.sig
+            );
+        }
         _setProfileMetadataURI(vars.profileId, vars.metadata);
     }
 

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -24,7 +24,6 @@ export const ERRORS = {
   NOT_COLLECT_NFT: 'CallerNotCollectNFT()',
   BLOCK_NUMBER_INVALID: 'BlockNumberInvalid()',
   INIT_PARAMS_INVALID: 'InitParamsInvalid()',
-  ZERO_CURRENCY: 'ZeroCurrency()',
   COLLECT_EXPIRED: 'CollectExpired()',
   COLLECT_NOT_ALLOWED: 'CollectNotAllowed()',
   MINT_LIMIT_EXCEEDED: 'MintLimitExceeded()',

--- a/test/hub/profiles/profile-creation.spec.ts
+++ b/test/hub/profiles/profile-creation.spec.ts
@@ -10,6 +10,7 @@ import {
   governance,
   lensHub,
   makeSuiteCleanRoom,
+  MAX_PROFILE_IMAGE_URI_LENGTH,
   mockFollowModule,
   mockModuleData,
   MOCK_FOLLOW_NFT_URI,
@@ -107,7 +108,7 @@ makeSuiteCleanRoom('Profile Creation', function () {
         ).to.be.revertedWith(ERRORS.NO_REASON_ABI_DECODE);
       });
 
-      it('User should fail to createa a profile when they are not a whitelisted profile creator', async function () {
+      it('User should fail to create a profile when they are not a whitelisted profile creator', async function () {
         await expect(
           lensHub.connect(governance).whitelistProfileCreator(userAddress, false)
         ).to.not.be.reverted;
@@ -122,6 +123,22 @@ makeSuiteCleanRoom('Profile Creation', function () {
             followNFTURI: MOCK_FOLLOW_NFT_URI,
           })
         ).to.be.revertedWith(ERRORS.PROFILE_CREATOR_NOT_WHITELISTED);
+      });
+
+      it('User should fail to create a profile with invalid image URI length', async function () {
+        const profileURITooLong = MOCK_PROFILE_URI.repeat(500);
+        expect(profileURITooLong.length).to.be.greaterThan(MAX_PROFILE_IMAGE_URI_LENGTH);
+
+        await expect(
+          lensHub.createProfile({
+            to: userAddress,
+            handle: MOCK_PROFILE_HANDLE,
+            imageURI: profileURITooLong,
+            followModule: ZERO_ADDRESS,
+            followModuleInitData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.be.revertedWith(ERRORS.INVALID_IMAGE_URI_LENGTH);
       });
     });
 


### PR DESCRIPTION
This PR (currently a draft) implements fixes from Peckshield's second Lens Protocol audit. This audit is valid for commit c0f44df794280ddb454195afcfbe550d40e0cca5