### PR TITLE
Feat: Prevent Emergency Admin From Setting State When Paused

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -93,6 +93,7 @@ contract LensHub is LensNFTBase, VersionedInitializable, LensMultiState, LensHub
         if (msg.sender == _emergencyAdmin) {
             if (newState == DataTypes.ProtocolState.Unpaused)
                 revert Errors.EmergencyAdminCannotUnpause();
+            _validateNotPaused();
         } else if (msg.sender != _governance) {
             revert Errors.NotGovernanceOrEmergencyAdmin();
         }

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -91,7 +91,9 @@ contract LensHub is LensNFTBase, VersionedInitializable, LensMultiState, LensHub
     /// @inheritdoc ILensHub
     function setState(DataTypes.ProtocolState newState) external override {
         if (msg.sender == _emergencyAdmin) {
-            if (newState < getState()) revert Errors.EmergencyAdminCannotUnpause();
+            if (newState == DataTypes.ProtocolState.Unpaused)
+                revert Errors.EmergencyAdminCannotUnpause();
+            _validateNotPaused();
         } else if (msg.sender != _governance) {
             revert Errors.NotGovernanceOrEmergencyAdmin();
         }

--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -91,9 +91,7 @@ contract LensHub is LensNFTBase, VersionedInitializable, LensMultiState, LensHub
     /// @inheritdoc ILensHub
     function setState(DataTypes.ProtocolState newState) external override {
         if (msg.sender == _emergencyAdmin) {
-            if (newState == DataTypes.ProtocolState.Unpaused)
-                revert Errors.EmergencyAdminCannotUnpause();
-            _validateNotPaused();
+            if (newState < getState()) revert Errors.EmergencyAdminCannotUnpause();
         } else if (msg.sender != _governance) {
             revert Errors.NotGovernanceOrEmergencyAdmin();
         }

--- a/contracts/core/base/LensMultiState.sol
+++ b/contracts/core/base/LensMultiState.sol
@@ -35,7 +35,7 @@ abstract contract LensMultiState {
      *      1: PublishingPaused
      *      2: Paused
      */
-    function getState() public view returns (DataTypes.ProtocolState) {
+    function getState() external view returns (DataTypes.ProtocolState) {
         return _state;
     }
 

--- a/contracts/core/base/LensMultiState.sol
+++ b/contracts/core/base/LensMultiState.sol
@@ -35,7 +35,7 @@ abstract contract LensMultiState {
      *      1: PublishingPaused
      *      2: Paused
      */
-    function getState() external view returns (DataTypes.ProtocolState) {
+    function getState() public view returns (DataTypes.ProtocolState) {
         return _state;
     }
 

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -46,6 +46,10 @@ interface ILensHub {
      * @notice Sets the protocol state to either a global pause, a publishing pause or an unpaused state. This function
      * can only be called by the governance address or the emergency admin address.
      *
+     * Note that this reverts if the emergency admin calls it if:
+     *      1. The emergency admin is attempting to unpause.
+     *      2. The emergency admin is calling while the protocol is already paused.
+     *
      * @param newState The state to set, as a member of the ProtocolState enum.
      */
     function setState(DataTypes.ProtocolState newState) external;
@@ -537,5 +541,4 @@ interface ILensHub {
      * @return address The collect NFT implementation address.
      */
     function getCollectNFTImpl() external view returns (address);
-
 }

--- a/test/hub/interactions/multi-state-hub.spec.ts
+++ b/test/hub/interactions/multi-state-hub.spec.ts
@@ -72,8 +72,8 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
       it('Governance should set user as emergency admin, user sets protocol state but fails to set emergency admin, governance sets emergency admin to the zero address, user fails to set protocol state', async function () {
         await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
 
-        await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
         await expect(lensHub.setEmergencyAdmin(ZERO_ADDRESS)).to.be.revertedWith(
           ERRORS.NOT_GOVERNANCE
         );

--- a/test/hub/interactions/multi-state-hub.spec.ts
+++ b/test/hub/interactions/multi-state-hub.spec.ts
@@ -51,20 +51,15 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         );
       });
 
-      it('Governance should set user as emergency admin, user should fail to set protocol state to Unpaused', async function () {
-        await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
-        await expect(lensHub.setState(ProtocolState.Unpaused)).to.be.revertedWith(
-          ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
-        );
-      });
-
-      it('Governance should set user as emergency admin, user should fail to set protocol state to PublishingPaused or Paused from Paused', async function () {
+      it('Governance should set user as emergency admin, user should fail to set protocol state to PublishingPaused or Unpaused from Paused', async function () {
         await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
         await expect(lensHub.connect(governance).setState(ProtocolState.Paused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.be.revertedWith(
-          ERRORS.PAUSED
+          ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
         );
-        await expect(lensHub.setState(ProtocolState.Paused)).to.be.revertedWith(ERRORS.PAUSED);
+        await expect(lensHub.setState(ProtocolState.Unpaused)).to.be.revertedWith(
+          ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
+        );
       });
     });
 
@@ -72,8 +67,8 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
       it('Governance should set user as emergency admin, user sets protocol state but fails to set emergency admin, governance sets emergency admin to the zero address, user fails to set protocol state', async function () {
         await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
 
-        await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
         await expect(lensHub.setEmergencyAdmin(ZERO_ADDRESS)).to.be.revertedWith(
           ERRORS.NOT_GOVERNANCE
         );
@@ -114,15 +109,8 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.be.revertedWith(
-          ERRORS.PAUSED
+          ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
         );
-      });
-
-      it('Governance should set user as emergency admin, user should set protocol state to PublishingPaused, then set it to PublishingPaused again without reverting', async function () {
-        await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
-
-        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
-        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
       });
     });
   });

--- a/test/hub/interactions/multi-state-hub.spec.ts
+++ b/test/hub/interactions/multi-state-hub.spec.ts
@@ -51,11 +51,20 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         );
       });
 
-      it('Governance should set user as emergency admin, user should fail to set protocol state to unpaused', async function () {
+      it('Governance should set user as emergency admin, user should fail to set protocol state to Unpaused', async function () {
         await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.Unpaused)).to.be.revertedWith(
           ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
         );
+      });
+
+      it('Governance should set user as emergency admin, user should fail to set protocol state to PublishingPaused or Paused from Paused', async function () {
+        await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
+        await expect(lensHub.connect(governance).setState(ProtocolState.Paused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.be.revertedWith(
+          ERRORS.PAUSED
+        );
+        await expect(lensHub.setState(ProtocolState.Paused)).to.be.revertedWith(ERRORS.PAUSED);
       });
     });
 
@@ -98,6 +107,23 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         ).to.not.be.reverted;
         expect(await lensHub.getState()).to.eq(ProtocolState.Unpaused);
       });
+
+      it('Governance should set user as emergency admin, user should set protocol state to PublishingPaused, then Paused, then fail to set it to PublishingPaused', async function () {
+        await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
+
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.be.revertedWith(
+          ERRORS.PAUSED
+        );
+      });
+
+      it('Governance should set user as emergency admin, user should set protocol state to PublishingPaused, then set it to PublishingPaused again without reverting', async function () {
+        await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
+
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
+      });
     });
   });
 
@@ -121,6 +147,7 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
           lensHub.transferFrom(userAddress, userTwoAddress, FIRST_PROFILE_ID)
         ).to.be.revertedWith(ERRORS.PAUSED);
       });
+
       it('Governance should pause the hub, profile creation should fail, then governance unpauses the hub and profile creation should work', async function () {
         await expect(lensHub.connect(governance).setState(ProtocolState.Paused)).to.not.be.reverted;
 

--- a/test/hub/interactions/multi-state-hub.spec.ts
+++ b/test/hub/interactions/multi-state-hub.spec.ts
@@ -51,15 +51,20 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         );
       });
 
-      it('Governance should set user as emergency admin, user should fail to set protocol state to PublishingPaused or Unpaused from Paused', async function () {
+      it('Governance should set user as emergency admin, user should fail to set protocol state to Unpaused', async function () {
         await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
-        await expect(lensHub.connect(governance).setState(ProtocolState.Paused)).to.not.be.reverted;
-        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.be.revertedWith(
-          ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
-        );
         await expect(lensHub.setState(ProtocolState.Unpaused)).to.be.revertedWith(
           ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
         );
+      });
+
+      it('Governance should set user as emergency admin, user should fail to set protocol state to PublishingPaused or Paused from Paused', async function () {
+        await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
+        await expect(lensHub.connect(governance).setState(ProtocolState.Paused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.be.revertedWith(
+          ERRORS.PAUSED
+        );
+        await expect(lensHub.setState(ProtocolState.Paused)).to.be.revertedWith(ERRORS.PAUSED);
       });
     });
 
@@ -67,8 +72,8 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
       it('Governance should set user as emergency admin, user sets protocol state but fails to set emergency admin, governance sets emergency admin to the zero address, user fails to set protocol state', async function () {
         await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
 
-        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
         await expect(lensHub.setEmergencyAdmin(ZERO_ADDRESS)).to.be.revertedWith(
           ERRORS.NOT_GOVERNANCE
         );
@@ -109,8 +114,15 @@ makeSuiteCleanRoom('Multi-State Hub', function () {
         await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.Paused)).to.not.be.reverted;
         await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.be.revertedWith(
-          ERRORS.EMERGENCY_ADMIN_CANNOT_UNPAUSE
+          ERRORS.PAUSED
         );
+      });
+
+      it('Governance should set user as emergency admin, user should set protocol state to PublishingPaused, then set it to PublishingPaused again without reverting', async function () {
+        await expect(lensHub.connect(governance).setEmergencyAdmin(userAddress)).to.not.be.reverted;
+
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
+        await expect(lensHub.setState(ProtocolState.PublishingPaused)).to.not.be.reverted;
       });
     });
   });

--- a/test/other/events.spec.ts
+++ b/test/other/events.spec.ts
@@ -148,23 +148,24 @@ makeSuiteCleanRoom('Events', function () {
 
     it('Protocol state change by emergency admin should emit expected events', async function () {
       await waitForTx(lensHub.connect(governance).setEmergencyAdmin(userAddress));
-      receipt = await waitForTx(lensHub.connect(user).setState(ProtocolState.Paused));
-
-      expect(receipt.logs.length).to.eq(1);
-      matchEvent(receipt, 'StateSet', [
-        userAddress,
-        ProtocolState.Unpaused,
-        ProtocolState.Paused,
-        await getTimestamp(),
-      ]);
 
       receipt = await waitForTx(lensHub.connect(user).setState(ProtocolState.PublishingPaused));
 
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'StateSet', [
         userAddress,
-        ProtocolState.Paused,
+        ProtocolState.Unpaused,
         ProtocolState.PublishingPaused,
+        await getTimestamp(),
+      ]);
+
+      receipt = await waitForTx(lensHub.connect(user).setState(ProtocolState.Paused));
+
+      expect(receipt.logs.length).to.eq(1);
+      matchEvent(receipt, 'StateSet', [
+        userAddress,
+        ProtocolState.PublishingPaused,
+        ProtocolState.Paused,
         await getTimestamp(),
       ]);
     });


### PR DESCRIPTION
This PR adds a reverting case if the emergency admin is attempting to call `setState()` if the protocol is already in a `Paused` state. 

This means that the emergency admin can go from `PublishingPaused => Paused` or from `PublishingPaused => PublishingPaused` (effectively achieving nothing) but can no longer go from `Paused => PublishingPaused`. This is in line with a previous change that prevented the emergency admin from setting the state to `Unpaused` in any circumstance.