### PR TITLE
Feat: Add A Main Profile Creation Proxy

### DIFF
--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -26,12 +26,14 @@ library Errors {
     error HandleTaken();
     error HandleLengthInvalid();
     error HandleContainsInvalidCharacters();
+    error HandleFirstCharInvalid();
     error ProfileImageURILengthInvalid();
     error CallerNotFollowNFT();
     error CallerNotCollectNFT();
     error BlockNumberInvalid();
     error ArrayMismatch();
     error CannotCommentOnSelf();
+    error NotWhitelisted();
 
     // Module Errors
     error InitParamsInvalid();

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -520,6 +520,4 @@ library Events {
      * @param timestamp The current block timestamp.
      */
     event ProfileMetadataSet(uint256 indexed profileId, string metadata, uint256 timestamp);
-
-    event ProfileCreationProxyCreatorWhitelisted(address indexed creator, bool indexed whitelisted);
 }

--- a/contracts/libraries/Events.sol
+++ b/contracts/libraries/Events.sol
@@ -519,9 +519,7 @@ library Events {
      * @param metadata The metadata set for the profile and user.
      * @param timestamp The current block timestamp.
      */
-    event ProfileMetadataSet(
-        uint256 indexed profileId,
-        string metadata,
-        uint256 timestamp
-    );
+    event ProfileMetadataSet(uint256 indexed profileId, string metadata, uint256 timestamp);
+
+    event ProfileCreationProxyCreatorWhitelisted(address indexed creator, bool indexed whitelisted);
 }

--- a/contracts/misc/ProfileCreationProxy.sol
+++ b/contracts/misc/ProfileCreationProxy.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {ILensHub} from '../interfaces/ILensHub.sol';
+import {DataTypes} from '../libraries/DataTypes.sol';
+import {Errors} from '../libraries/Errors.sol';
+import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
+
+/**
+ * @title ProfileCreationProxy
+ * @author Lens Protocol
+ *
+ * @notice This is an ownable proxy contract that enforces ".lens" handle suffixes at profile creation.
+ * Only the owner can create profiles.
+ */
+contract ProfileCreationProxy is Ownable {
+    ILensHub immutable LENS_HUB;
+
+    mapping(address => bool) internal _whitelisted;
+
+    modifier onlyWhitelisted() {
+        if (!_whitelisted[msg.sender]) revert Errors.NotWhitelisted();
+        _;
+    }
+
+    constructor(address owner, ILensHub hub) {
+        _transferOwnership(owner);
+        LENS_HUB = hub;
+    }
+
+    function whitelist(address creator, bool toWhitelist) external onlyOwner {
+        _whitelisted[creator] = toWhitelist;
+    }
+
+    function proxyCreateProfile(DataTypes.CreateProfileData memory vars) external onlyWhitelisted {
+        uint256 handleLength = bytes(vars.handle).length;
+        if (handleLength < 5) revert Errors.HandleLengthInvalid();
+        bytes1 firstByte = bytes(vars.handle)[0];
+        if (firstByte == '-' || firstByte == '_' || firstByte == '.')
+            revert Errors.HandleFirstCharInvalid();
+        for (uint256 i = 1; i < handleLength; ) {
+            if (bytes(vars.handle)[i] == '.') revert Errors.HandleContainsInvalidCharacters();
+            unchecked {
+                ++i;
+            }
+        }
+        vars.handle = string(abi.encodePacked(vars.handle, '.lens'));
+        LENS_HUB.createProfile(vars);
+    }
+}

--- a/contracts/misc/ProfileCreationProxy.sol
+++ b/contracts/misc/ProfileCreationProxy.sol
@@ -36,15 +36,18 @@ contract ProfileCreationProxy is Ownable {
     function proxyCreateProfile(DataTypes.CreateProfileData memory vars) external onlyWhitelisted {
         uint256 handleLength = bytes(vars.handle).length;
         if (handleLength < 5) revert Errors.HandleLengthInvalid();
+
         bytes1 firstByte = bytes(vars.handle)[0];
         if (firstByte == '-' || firstByte == '_' || firstByte == '.')
             revert Errors.HandleFirstCharInvalid();
+
         for (uint256 i = 1; i < handleLength; ) {
             if (bytes(vars.handle)[i] == '.') revert Errors.HandleContainsInvalidCharacters();
             unchecked {
                 ++i;
             }
         }
+
         vars.handle = string(abi.encodePacked(vars.handle, '.lens'));
         LENS_HUB.createProfile(vars);
     }

--- a/contracts/misc/ProfileCreationProxy.sol
+++ b/contracts/misc/ProfileCreationProxy.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.10;
 import {ILensHub} from '../interfaces/ILensHub.sol';
 import {DataTypes} from '../libraries/DataTypes.sol';
 import {Errors} from '../libraries/Errors.sol';
+import {Events} from '../libraries/Events.sol';
 import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
 
 /**
@@ -31,6 +32,7 @@ contract ProfileCreationProxy is Ownable {
 
     function whitelist(address creator, bool toWhitelist) external onlyOwner {
         _whitelisted[creator] = toWhitelist;
+        emit Events.ProfileCreationProxyCreatorWhitelisted(creator, toWhitelist);
     }
 
     function proxyCreateProfile(DataTypes.CreateProfileData memory vars) external onlyWhitelisted {

--- a/contracts/misc/ProfileCreationProxy.sol
+++ b/contracts/misc/ProfileCreationProxy.sol
@@ -18,24 +18,12 @@ import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
 contract ProfileCreationProxy is Ownable {
     ILensHub immutable LENS_HUB;
 
-    mapping(address => bool) internal _whitelisted;
-
-    modifier onlyWhitelisted() {
-        if (!_whitelisted[msg.sender]) revert Errors.NotWhitelisted();
-        _;
-    }
-
     constructor(address owner, ILensHub hub) {
         _transferOwnership(owner);
         LENS_HUB = hub;
     }
 
-    function whitelist(address creator, bool toWhitelist) external onlyOwner {
-        _whitelisted[creator] = toWhitelist;
-        emit Events.ProfileCreationProxyCreatorWhitelisted(creator, toWhitelist);
-    }
-
-    function proxyCreateProfile(DataTypes.CreateProfileData memory vars) external onlyWhitelisted {
+    function proxyCreateProfile(DataTypes.CreateProfileData memory vars) external onlyOwner {
         uint256 handleLength = bytes(vars.handle).length;
         if (handleLength < 5) revert Errors.HandleLengthInvalid();
 

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -22,6 +22,7 @@ export const ERRORS = {
   INVALID_HANDLE_LENGTH: 'HandleLengthInvalid()',
   INVALID_IMAGE_URI_LENGTH: 'ProfileImageURILengthInvalid()',
   HANDLE_CONTAINS_INVALID_CHARACTERS: 'HandleContainsInvalidCharacters()',
+  HANDLE_FIRST_CHARACTER_INVALID: 'HandleFirstCharInvalid()',
   NOT_FOLLOW_NFT: 'CallerNotFollowNFT()',
   NOT_COLLECT_NFT: 'CallerNotCollectNFT()',
   BLOCK_NUMBER_INVALID: 'BlockNumberInvalid()',

--- a/test/other/profile-creation-proxy.spec.ts
+++ b/test/other/profile-creation-proxy.spec.ts
@@ -1,0 +1,137 @@
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { ZERO_ADDRESS } from '../helpers/constants';
+import { ERRORS } from '../helpers/errors';
+import { ProfileCreationProxy, ProfileCreationProxy__factory } from '../../typechain-types';
+import {
+  deployer,
+  FIRST_PROFILE_ID,
+  governance,
+  lensHub,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_URI,
+  user,
+  userAddress,
+  deployerAddress,
+} from '../__setup.spec';
+import { BigNumber } from 'ethers';
+import { TokenDataStructOutput } from '../../typechain-types/LensHub';
+import { getTimestamp } from '../helpers/utils';
+
+makeSuiteCleanRoom('Profile Creation Proxy', function () {
+  const REQUIRED_SUFFIX = '.lens';
+  const MINIMUM_LENGTH = 5;
+
+  let profileCreationProxy: ProfileCreationProxy;
+  beforeEach(async function () {
+    profileCreationProxy = await new ProfileCreationProxy__factory(deployer).deploy(
+      deployerAddress,
+      lensHub.address
+    );
+    await expect(
+      lensHub.connect(governance).whitelistProfileCreator(profileCreationProxy.address, true)
+    ).to.not.be.reverted;
+  });
+
+  context('Negatives', function () {
+    it('Should fail to create profile if handle length before suffix does not reach minimum length', async function () {
+      const handle = 'a'.repeat(MINIMUM_LENGTH - 1);
+      await expect(
+        profileCreationProxy.proxyCreateProfile({
+          to: userAddress,
+          handle: handle,
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleInitData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.be.revertedWith(ERRORS.INVALID_HANDLE_LENGTH);
+    });
+
+    it('Should fail to create profile if handle contains an invalid character before the suffix', async function () {
+      await expect(
+        profileCreationProxy.proxyCreateProfile({
+          to: userAddress,
+          handle: 'dots.are.invalid',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleInitData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.be.revertedWith(ERRORS.HANDLE_CONTAINS_INVALID_CHARACTERS);
+    });
+
+    it('Should fail to create profile if handle starts with a dash, underscore or period', async function () {
+      await expect(
+        profileCreationProxy.proxyCreateProfile({
+          to: userAddress,
+          handle: '.abcdef',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleInitData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.be.revertedWith(ERRORS.HANDLE_FIRST_CHARACTER_INVALID);
+
+      await expect(
+        profileCreationProxy.proxyCreateProfile({
+          to: userAddress,
+          handle: '-abcdef',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleInitData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.be.revertedWith(ERRORS.HANDLE_FIRST_CHARACTER_INVALID);
+
+      await expect(
+        profileCreationProxy.proxyCreateProfile({
+          to: userAddress,
+          handle: '_abcdef',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleInitData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.be.revertedWith(ERRORS.HANDLE_FIRST_CHARACTER_INVALID);
+    });
+  });
+
+  context('Scenarios', function () {
+    it('Should be able to create a profile using the whitelisted proxy, received NFT should be valid', async function () {
+      let timestamp: any;
+      let owner: string;
+      let totalSupply: BigNumber;
+      let profileId: BigNumber;
+      let mintTimestamp: BigNumber;
+      let tokenData: TokenDataStructOutput;
+      const validHandleBeforeSuffix = 'v_al-id';
+      const expectedHandle = 'v_al-id'.concat(REQUIRED_SUFFIX);
+
+      await expect(
+        profileCreationProxy.proxyCreateProfile({
+          to: userAddress,
+          handle: validHandleBeforeSuffix,
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleInitData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+
+      timestamp = await getTimestamp();
+      owner = await lensHub.ownerOf(FIRST_PROFILE_ID);
+      totalSupply = await lensHub.totalSupply();
+      profileId = await lensHub.getProfileIdByHandle(expectedHandle);
+      mintTimestamp = await lensHub.mintTimestampOf(FIRST_PROFILE_ID);
+      tokenData = await lensHub.tokenDataOf(FIRST_PROFILE_ID);
+      expect(owner).to.eq(userAddress);
+      expect(totalSupply).to.eq(FIRST_PROFILE_ID);
+      expect(profileId).to.eq(FIRST_PROFILE_ID);
+      expect(mintTimestamp).to.eq(timestamp);
+      expect(tokenData.owner).to.eq(userAddress);
+      expect(tokenData.mintTimestamp).to.eq(timestamp);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a profile creation proxy that allows a specific owner to create profiles while enforcing certain rules: 

1. The handle must not start with "-" or "_"
2. The handle must not contain a "."
3. The handle length must be greater than or equal to 5 characters (in our case, due to our limited character set, this is 5 bytes)
4. The handle is appended with a ".lens"

Note that the basic handle limitations still persist, so the handle length cannot be greater than 31 bytes (including the suffix).