### PR TITLE
Remove assembly if statement at InteractionHelpers to prevent solidity coverage compilation bug

### DIFF
--- a/contracts/libraries/InteractionHelpers.sol
+++ b/contracts/libraries/InteractionHelpers.sol
@@ -31,12 +31,7 @@ library InteractionHelpers {
         address follower,
         uint256[] calldata profileIds,
         bytes[] calldata followModuleDatas //,
-    )
-        internal
-        returns (
-            uint256[] memory
-        )
-    {
+    ) internal returns (uint256[] memory) {
         if (profileIds.length != followModuleDatas.length) revert Errors.ArrayMismatch();
         uint256[] memory tokenIds = new uint256[](profileIds.length);
 
@@ -52,10 +47,10 @@ library InteractionHelpers {
                 // The follow NFT offset is 2, the follow module offset is 1,
                 // so we just need to subtract 1 instead of recalculating the slot.
                 followNFTSlot := add(keccak256(0, 64), PROFILE_FOLLOW_NFT_OFFSET)
-                followModule := sload(sub(followNFTSlot,1))
+                followModule := sload(sub(followNFTSlot, 1))
                 followNFT := sload(followNFTSlot)
             }
-            
+
             if (followNFT == address(0)) {
                 followNFT = _deployFollowNFT(profileId);
                 assembly {
@@ -211,7 +206,7 @@ library InteractionHelpers {
     }
 
     function _validateProfileExistsViaHandle(uint256 profileId) private view {
-        bool shouldRevert;
+        uint8 shouldRevert;
         assembly {
             // Load the free memory pointer, where we'll return the value
             let ptr := mload(64)
@@ -258,18 +253,15 @@ library InteractionHelpers {
                     mstore(add(add(ptr, 32), mul(32, i)), sload(add(handleSlot, i)))
                 }
             }
-
             let handleHash := keccak256(add(ptr, 32), size)
             mstore(0, handleHash)
             mstore(32, PROFILE_ID_BY_HANDLE_HASH_MAPPING_SLOT)
             let handleHashSlot := keccak256(0, 64)
             let resolvedProfileId := sload(handleHashSlot)
-            if iszero(eq(resolvedProfileId, profileId)) {
-                shouldRevert := true
-            }
+            shouldRevert := iszero(eq(resolvedProfileId, profileId))
             // Store the new memory pointer in the free memory pointer slot
             mstore(64, add(add(ptr, 32), size))
         }
-        if (shouldRevert) revert Errors.TokenDoesNotExist();
+        if (shouldRevert == 1) revert Errors.TokenDoesNotExist();
     }
 }


### PR DESCRIPTION
At `refactor/library-refactor` branch Solidity Coverage plugin fails to compile with the following error:

```
Error in plugin solidity-coverage: RangeError: Could not instrument: libraries/InteractionHelpers.sol. (Please verify solc can compile this file without errors.) index parameter must be between >= 0 and <= number of children.
```
After investigating the cause of the bug was an assignment of the "shouldRevert" variable inside the if statement block, still not sure about why the solidity-coverage compilation fails, would be good to open an issue.

Made a minor refactor of the logic to remove the assembly if statement, replacing shouldRevert with a uint8 type that returns the result of the previous if statement condition. After the assembly block the if statement checks if shouldRevert  is `1`,  reverting if the condition is met.
```
assembly {
  {...}
  shouldRevert := iszero(eq(resolvedProfileId, profileId))
  {...}
}

// Outside of assembly block
if (shouldRevert == 1) revert Errors.TokenDoesNotExist();
```

Accidentally seems a bit cheaper in terms of gas (~5-15 gas cheaper):

| Function           | Min    | Max    | Avg    |
|--------------------|--------|--------|--------|
| follow (with fix)  | 198125 | 727727 | 423716 |
| follow             | 198130 | 727742 | 423722 |
